### PR TITLE
In arpeggioes, add note to key on queue instead of keying on immediately

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -992,7 +992,9 @@ HandleArpeggio:				; Routine that controls all things arpeggio-related.
 	pop	a
 	bne	.return			; |
 +
-	jmp	KeyOnVoices		; / Key on this voice.
+	or	a, $47			; / Set this voice to be keyed on.
+	mov	$47, a
+	ret
 	
 .trill
 	mov	a, !ArpCurrentDelta+x	; \ Opposite note.


### PR DESCRIPTION
Keying on immediately causes clicks on the first note, thus the operation has
been modified to instead add the note to the queue to keying on notes, since it
is already done there.

This commit closes #4.