### PR TITLE
Add exact tick for l directive and dotted exact tick note support

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -569,12 +569,11 @@ void Music::parseLDirective()
 			error("Error parsing \"l\" directive.");
 		}
 		defaultNoteLength = i;
-		return;
 	}
-	if (i == -1) error("Error parsing \"l\" directive.")
-	if (i < 1 || i > 192) error("Illegal value for \"l\" directive.")
-
-	defaultNoteLength = 192 / i;
+	else if (i == -1) error("Error parsing \"l\" directive.")
+	else if (i < 1 || i > 192) error("Illegal value for \"l\" directive.")
+	else {defaultNoteLength = 192 / i;}
+	defaultNoteLength = getNoteLengthModifier(defaultNoteLength);
 }
 void Music::parseGlobalVolumeCommand()
 {
@@ -2815,6 +2814,10 @@ int Music::getNoteLength(int i)
 	else if (i < 1 || i > 192) i = defaultNoteLength;
 	else i = 192 / i;
 
+	return getNoteLengthModifier(i);
+}
+
+int Music::getNoteLengthModifier(int i) {
 	int frac = i;
 
 	int times = 0;
@@ -2831,6 +2834,7 @@ int Music::getNoteLength(int i)
 		i = (int)floor(((double)i * 2.0 / 3.0) + 0.5);
 	return i;
 }
+
 
 bool sortTempoPair(const std::pair<double, int> &p1, const std::pair<double, int> &p2)
 {

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -559,11 +559,22 @@ void Music::parseLDirective()
 {
 	pos++;
 	i = getInt();
+	if (i == -1 && text[pos] == '=')
+	{
+		pos++;
+		i = getInt();
 
+		if (i == -1)
+		{
+			error("Error parsing \"l\" directive.");
+		}
+		defaultNoteLength = i;
+		return;
+	}
 	if (i == -1) error("Error parsing \"l\" directive.")
 	if (i < 1 || i > 192) error("Illegal value for \"l\" directive.")
 
-		defaultNoteLength = i;
+	defaultNoteLength = 192 / i;
 }
 void Music::parseGlobalVolumeCommand()
 {
@@ -2795,14 +2806,14 @@ int Music::getNoteLength(int i)
 		{
 			printError("Error parsing note", false, name, line);
 		}
-		return i;
+		//return i;
 		//if (i < 1) still = false; else return i;
 	}
 
 	//if (still)
 	//{
-	if (i < 1 || i > 192) i = defaultNoteLength;
-	i = 192 / i;
+	else if (i < 1 || i > 192) i = defaultNoteLength;
+	else i = 192 / i;
 
 	int frac = i;
 

--- a/src/AddmusicK/Music.h
+++ b/src/AddmusicK/Music.h
@@ -167,6 +167,7 @@ private:
 	int getHex(bool anyLength = false);
 	int getPitch(int j);
 	int getNoteLength(int);
+	int getNoteLengthModifier(int);
 
 	bool guessLength;
 	int resizedChannel;


### PR DESCRIPTION
This merge request references #1. Tie support for l directive is not implemented here
due to a conflict with the actual tie command used by the sound driver itself.