### PR TITLE
Increment position after reading octave during $DD VCMD validation

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -1957,6 +1957,7 @@ void Music::parseHexCommand()
 					skipSpaces;
 					if (text[pos] == 'o')
 					{
+						pos++;
 						getInt();
 					}
 					else if (text[pos] == 'a' || text[pos] == 'b' || text[pos] == 'c' || text[pos] == 'd' || text[pos] == 'e' || text[pos] == 'f' || text[pos] == 'g' ||


### PR DESCRIPTION
An infinite loop was occurring during validation due to getInt failing to read
any numbers due to a failure to increment the pointer.

This merge request closes #27.