### PR TITLE
Global songs update

### DIFF
--- a/music/originals/02 Game Over.txt
+++ b/music/originals/02 Game Over.txt
@@ -1,4 +1,10 @@
-;title=Game Over
+#SPC
+{
+	#author "Koji Kondo"
+	#title "Game Over"
+	#game "Super Mario World"
+}
+
 ;ported by gocha
 
 "VCMD_ECHO_OFF=$f0"

--- a/music/originals/03 Boss Clear.txt
+++ b/music/originals/03 Boss Clear.txt
@@ -1,4 +1,10 @@
-;title=Sub Castle Clear Fanfare
+#SPC
+{
+	#author "Koji Kondo"
+	#title "Boss Clear"
+	#game "Super Mario World"
+}
+
 ;ported by gocha
 
 "VCMD_PAN_FADE=$dc"
@@ -75,7 +81,7 @@ VCMD_ECHO_OFF
 	@4 y10
 	q7e
 	l2 @26c^ l16 ^^ @26c@26c@26c^@26c^ l12 @26c@26c@26c @26c2 @26c@26c@26c
-	[q7d l32 @26c]22 q6f @26c=12 ;c4-=36
+	[[q7d l32 @26c]]22 q6f @26c=12 ;c4-=36
 
 #5	r=84
 
@@ -85,20 +91,17 @@ VCMD_ECHO_OFF
 	y10 q7e
 	o2 c2 ^2 ^8 c16 c16 c8 c8 c12 c+12 d12 d+2 d+12 d+12 d+12 f2 ^4
 
-#6	r=84
+#6	[r=84
 
 	; $139C / $2CFE
-	@2 y20 q6b
-	r2 r2 VCMD_PAN_FADE $90 $00
-	o4 l32 ga+>dd+<a+>dd+gdd+ga+d+ga+>d<ga+>dd+<a+>dd+g l2 a+rr
+	@2 y20
+	r2 r2 VCMD_PAN_FADE $90 $00]
+	q6b o4 h-5 l32 ga+>dd+<a+>dd+gdd+ga+d+ga+>d<ga+>dd+<a+>dd+g l2 a+rr
 
-#7	
-r=84
-
+#7
 	; $139C / $2D27
-	@2 y20 q69
-	r48 r2 r2 VCMD_PAN_FADE $90 $00
-	o4 l32 ga+>dd+<a+>dd+gdd+ga+d+ga+>d<ga+>dd+<a+>dd+g l2 a+rr
+	r48 *
+	q69 o4 h-5 l32 ga+>dd+<a+>dd+gdd+ga+d+ga+>d<ga+>dd+<a+>dd+g l2 a+rr
                 
 
 #amk 2

--- a/music/originals/04 Stage Clear.txt
+++ b/music/originals/04 Stage Clear.txt
@@ -1,4 +1,10 @@
-;title=Course Clear Fanfare
+#SPC
+{
+	#author "Koji Kondo"
+	#title "Stage Clear"
+	#game "Super Mario World"
+}
+
 ;ported by gocha
 
 "VCMD_PAN_FADE=$dc"

--- a/music/originals/05 Starman.txt
+++ b/music/originals/05 Starman.txt
@@ -1,3 +1,9 @@
+#SPC
+{
+	#author "Koji Kondo"
+	#title "Starman"
+	#game "Super Mario World"
+}
 
 #option TempoImmunity
 
@@ -14,9 +20,9 @@ t56 @1 y10 q3E o5 c8 c8 c8 r16 c16 r16 c8. c8 c8 o4 b8 b8 b8 r16 b8 b8. b8 b8
 @1 y20 q3E o4 f8 f8 f8 d16 f8 f8 d16 f16 d16 f8 e8 e8 e8 c16 e8 e8 c16 e16 c16 e8 
 
 #5
-y20 q6D @22c16 @22c16 @22c16 @22c16 @23c8 @22c16 @22c16 @22c16 @22c16 @22c16 @22c16 @23c8 @22c16 @22c16 @22c16 @22c16 @22c16 @22c16 @23c8 @22c16 @22c16 @22c16 @22c16 @22c16 @22c16 @23c8 @22c16 @22c16 
+[[y20 q6D @22c16 @22c16 @22c16 @22c16 @23c8 @22c16 @22c16]]4
 
-                
+
 
 #amk 2
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    

--- a/music/originals/06 P-switch.txt
+++ b/music/originals/06 P-switch.txt
@@ -1,3 +1,10 @@
+#SPC
+{
+	#author "Koji Kondo"
+	#title "P-Switch"
+	#game "Super Mario World"
+}
+
 #option TempoImmunity
 
 #0
@@ -19,11 +26,9 @@ $DC$60$14 c+=16 g+=8 ^=24 o3 c+=24 o2 g+=24]3
 
 #2
 (3)[@12 y10 q6B
-o4 g=8 g=8 o5 e=8 e=8 o4 g=8 g=8 o5 e=8 e=8
-o4 g=8 g=8 o5 e=8 e=8 o4 g=8 g=8 o5 e=8 e=8
-o4 g=8 g=8 o5 e=8 e=8 o4 g=8 g=8 o5 e=8 e=8]3
+o4 g=8 g=8 o5 e=8 e=8]18
 /
-(3)1                
+(3)6
 
 #amk 2
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 

--- a/music/originals/07 Keyhole.txt
+++ b/music/originals/07 Keyhole.txt
@@ -1,3 +1,10 @@
+#SPC
+{
+	#author "Koji Kondo"
+	#title "Keyhole"
+	#game "Super Mario World"
+}
+
 #option TempoImmunity
 #option NoLoop
 

--- a/music/originals/08 Iris Out.txt
+++ b/music/originals/08 Iris Out.txt
@@ -1,3 +1,10 @@
+#SPC
+{
+	#author "Koji Kondo"
+	#title "Iris Out"
+	#game "Super Mario World"
+}
+
 #option TempoImmunity
 #option NoLoop
 

--- a/music/originals/09 Bonus End.txt
+++ b/music/originals/09 Bonus End.txt
@@ -1,4 +1,10 @@
-;title=Bonus Screen Clear Fanfare
+#SPC
+{
+	#author "Koji Kondo"
+	#title "Bonus Game Clear"
+	#game "Super Mario World"
+}
+
 ;ported by gocha
 ;@12 => h-5
 
@@ -7,13 +13,9 @@
 #option TempoImmunity
 #option NoLoop
 
-#0	
-	@1 y10 t64
+#0	@1 y10 t64
 	VCMD_PITCHENV_FROM $00 $06 $08
 	q5d o6 l4 dddd l8 cc<agf4 @15 < f^
-
-	; halt
-	/ r
 
 #1	@7 y10 q59
 	o2 l8 a+>>d<<a+>>d<<b>>d<<b>>d<c>e<c>e<<frfr
@@ -23,7 +25,7 @@
 
 #3	@12 ;y15
 	y10 ;v255
-	q6f o5 c8.<g16a8>c8.<g16a8>c16e16<g16a16>c8.<g16a8>c8c8^8c8^8
+	q6f o5 [[c8.<g16a8>]]2 c16e16<g16a16>c8.<g16a8>c8c8^8c8^8
 
 #5	@2 y5 q59
 	o6 l4 gggg l8 ffdc<a+4 @15 < f^
@@ -34,7 +36,7 @@
 
 #7	@7 y15 q59
 	o4 l8 rfrfrfrfrgrgcrcr
-                
+
 
 #amk 2
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+


### PR DESCRIPTION
- Added #spc tags to every global song.
- Fixed wrong note that played in "Bonus End" after the song was supposed to be over (because of "/ r" in the first channel, which was pointless anyway because of "#option NoLoop"). This also saved a handful of bytes by removing the intro commands.
- Optimized some global songs, for a total of 68 bytes saved:
    - "03 Boss Clear" 0x1CB -> 0x1C7
    - "05 Starman" 0xBC -> 0xA5
    - "06 P-Switch" 0xB0 -> 0x9C
    - "09 Bonus End" 0xD9 -> 0xC4