### PR TITLE
Force !SFXEchoChannels to zero when initializing a song

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1391,7 +1391,7 @@ PlaySong:
 	;mov	y, #$00		
 	;mov	$0387, y		; Zero out the tempo modifier.
 	
-	mov	!SFXEchoChannels, y
+	mov	!SFXEchoChannels, #$00
 L_0B5A:
 	mov	$06, a		; Song number goes into $06.
 	push	a


### PR DESCRIPTION
This looks like it was the intended method. A possible bug was accidentally
introduced when the slowdown fix was implemented where if a tick should
immediately fire after a long time since the timer was last read, then the
channels set up for using SFX would end up non-zero.

This merge request closes #39.