### PR TITLE
Pitch envelopes defined by music should not interfere with SFX

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -469,7 +469,9 @@ NoPitchAdjust:
 	mov	$b0+x, a	; /
 	or	($5c), ($48)       ; set volume changed flg
 	or	($47), ($48)       ; set key on shadow vbit
-	
+
+	mov	a, $48		; If $48 is 0, then this is SFX code.
+	beq	L_062B		; Don't adjust the pitch.	
 	mov	a, $0300+x	; \ 
 	mov	$90+x, a	; / 
 	beq	L_062B


### PR DESCRIPTION
Pitch envelopes set by the $EB and $EC VCMDs were still being set off on a
per-note basis whenever SFX triggered on them. Thus, some code was added on to
bypass this behavior.
This merge request closes #43.