### PR TITLE
Pitch envelopes defined by music should not interfere with SFX

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1073,7 +1073,8 @@ ProcessSFXInput:				; X = channel number * 2 to play a potential SFX on, y = inp
 						;
 	call	EffectModifier
 	mov	a, #$00				; \
-	mov	$0300+x, a			; /
+	mov	$90+x, a			; |
+	mov	$91+x, a			; /
 .return						;
 	;ret					;
 						;
@@ -1240,16 +1241,7 @@ L_0A14:
 	
 	call	KeyOffVoices
 	set1	$1d.7		; Turn off channel 7's music
-	mov	a, #$00		;
-;Bugfix by KungFuFurby 11/20/20:
-;Avoid zeroing out memory locations reserved by arpeggio (since they're
-;not used by the SFX at all)
-	mov	y, #$10		;
-L_0A28:				; \
-	mov	$02ff+y, a	; | $0300-$030f = #$00.  Dunno why, though.
-	mov	$031f+y, a	; | $0320-$032f = #$00.  Dunno why, though.
-	dbnz	y, L_0A28	; | 
-	ret			; /
+	ret
 L_0A2E:
 	dec	$0383
 	bne	L_0A0D
@@ -1346,15 +1338,6 @@ L_0ACE:
 	;mov	y, #$5c
 	call	KeyOffVoices             ; key off voice 7 now
 	set1	$1d.7
-	mov	a, #$00
-;Bugfix by KungFuFurby 11/20/20:
-;Avoid zeroing out memory locations reserved by arpeggio (since they're
-;not used by the SFX at all)
-	mov	y, #$10
-L_0AE2:
-	mov	$02ff+y, a
-	mov	$031f+y, a
-	dbnz	y, L_0AE2
 L_0AE7:
 	ret
 ;

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1261,6 +1261,7 @@ L_0A38:
 	bra	L_0A99
 ;
 L_0A51:						;;;;;;;;/ Code change
+	mov	$48, #$00		; Let NoteVCMD know that this is SFX code.
 	mov	a, $0383			; Process the jump SFX.
 	bne	L_0A2E			; I don't really know what's going on here, so I won't pretend to.
 	dbnz	$1c, L_0A38
@@ -1358,6 +1359,7 @@ L_0AF7:
 	call	NoteVCMD
 	bra	L_0B1C
 L_0B08:
+	mov	$48, #$00		; Let NoteVCMD know that this is SFX code.
 	mov	a, $0383
 	bne	L_0AE8
 	dbnz	$1c, L_0AF2


### PR DESCRIPTION
This is the sequel to pull request #47. An edge case was caught where the pitch envelope would still sneak into the SFX, and pitch envelopes were not being properly restored after the SFX was being played. Thanks to the bypass code being added on earlier, these can now be preserved instead of being cleared.

In addition, CPUIO1 SFX were added to the scope of what was not being restored pitch envelope-wise, and additional interferences to the pitch of the note were also removed so that it now works just like the normal SFX (except for, naturally, being hard-coded).

This merge request closes #43 (again).