### PR TITLE
Don't reset noise clock while SFX is utilizing it when changing songs

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -443,10 +443,9 @@ L_0F22:
 	movw	$63, ya            ; zero echo vol R shadow
 	call	L_0EEB             ; set echo vol DSP regs from shadows
 	;mov   $2e, a             ; zero 2E (but it's never used?)
-	or	a, #$20
-	mov	y, #$6c
-	mov	!NCKValue, a
-	jmp	DSPWrite             ; disable echo write, noise freq 0
+	mov	a, !NCKValue
+	or	!NCKValue, #$20           ; disable echo write
+	jmp	ModifyNoise
 }
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 cmdF1:					; Echo command 2 (delay, feedback, FIR)
@@ -468,7 +467,7 @@ cmdF1:					; Echo command 2 (delay, feedback, FIR)
 	;mov	$f2, #$6c		; \ Enable echo and sound once again.
 	;mov	$f3, !NCKValue		; /
 	and	!NCKValue, #$1f
-	mov	a, #$00
+	mov	a, !NCKValue
 	call	ModifyNoise
 	
 	call	GetCommandData		; From here on is the normal code.
@@ -523,7 +522,7 @@ GetBufferAddress:
 	
 	
 ModifyEchoDelay:			; a should contain the requested delay.
-
+	mov	$10, !NCKValue
 	push	a			; Save the requested delay.
 	call	GetBufferAddress
 	push	y
@@ -554,7 +553,7 @@ ModifyEchoDelay:			; a should contain the requested delay.
 	call	WaitForDelay		; > Clear out the RAM associated with the new echo buffer.  This way we avoid noise from whatever data was there before.
 	
 	mov	!NCKValue, #$00
-	mov	a, #$00
+	mov	a, $10
 	jmp	ModifyNoise
 	
 }
@@ -803,8 +802,8 @@ SubC_table2:
 	mov	$f2, #$7d		; | Write the new delay.
 	mov	$f3, a			; /
 	
+	mov	a, !NCKValue
 	and	!NCKValue, #$20
-	mov	a, #$00
 	jmp	ModifyNoise
 	
 	ret

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1493,9 +1493,11 @@ L_0BA3:
 	mov	$06, a		; ???
 L_0BA5:
 	mov	a, !NCKValue		; \ 
-	and	a, #$20			; | Disable mute and reset, reset the noise clock, keep echo off.
-	mov	!NCKValue, a		; |
-	mov	a, #$00			; |
+	and	!NCKValue, #$20		; | Disable mute and reset, keep echo off.
+	cmp	!SFXNoiseChannels, #$00
+	bne	+
+	mov	a, #$00			; | Only reset the noise clock if SFX is not using it.
++
 	call	ModifyNoise		; /
 	mov	a, $1d		
 	eor	a, #$ff		


### PR DESCRIPTION
This merge request closes #16, closes #76 and closes #77.

All three are involved at the same time because the echo code is involved and thus they are intertwined with each other.

Small piece of fine print: when setting up the EDL, if the entire sound has to be muted, the noise clock is allowed to temporarily become zero. It is restored after the setup is done, though.