### PR TITLE
 Terminate SFX sequence and don't disable SFX flag when CPUIO1 SFX triggers

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -891,6 +891,17 @@ PSwitchCh7:
 	
 endif
 
+SFXTerminateVCMD:
+	db $00
+
+SFXTerminateCh:
+	mov	a, #SFXTerminateVCMD&$ff
+	mov	!ChSFXPtrs+x, a
+	mov	a, #SFXTerminateVCMD>>8
+	mov	!ChSFXPtrs+1+x, a
+	mov	a, #$03
+	mov	!ChSFXNoteTimer|$0100+x, a
+	ret
 
 SpeedUpMusic:
 	mov	a, #$0a

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -662,8 +662,16 @@ EndSFX:
 					; Of course, that doesn't work so well when some channels don't map to input ports...
 				
 	
-	mov	a, $18			; \
+	mov	a, $18
+	bpl	+			
+	push	a
+	mov	a, $0383
+	or	a, $1c
+	pop	a
+	bne	++
++					; \
 	tclr	$1d, a			; | Clear the bit of $1d that this SFX corresponds to.
+++
 	tclr	!SFXNoiseChannels, a	; / Turn noise off for this channel's SFX.
 
 	call	EffectModifier
@@ -1225,7 +1233,8 @@ L_0A14:
 	
 	call	KeyOffVoices
 	set1	$1d.7		; Turn off channel 7's music
-	ret
+	mov	x, #$0e
+	jmp	SFXTerminateCh
 ; $01 = 01
 L_0A2E:
 	dec	$0383


### PR DESCRIPTION
Contains a snippet of code initially created for #55: specifically it comes from commit c9dd1f53ccb4a396c12bab389f27d6566c43ac0d. There was no specific commit for that snippet of code without accidentally grabbing other code outside of the scope of what this did, so it was not cherry-picked.

CPUIO1 SFX conveniently has a timer present to wait for the SFX to start up, meaning the sequence can be terminated without too many interruptions occurring. However, this requires an extra check being coded to detect a CPUIO1 SFX on standby, otherwise the CPUIO1 SFX is in danger of being overwritten by the music.

This merge request closes #79.