### PR TITLE
Set default note length on initialization to real ticks instead of divisor

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -211,7 +211,7 @@ void Music::init()
 	channel = 0;
 	octave = 4;
 	prevNoteLength = -1;
-	defaultNoteLength = 8;
+	defaultNoteLength = 192/8;
 
 	prevLoop = -1;
 	i = 0;


### PR DESCRIPTION
The parser was updated to use real ticks for the default note length when exact
tick note lengths were implemented. This parameter was not updated to account
for this change, causing errors for those that relied on the default note
length being 24 ticks on song initialization.

This commit closes #90.