### PR TITLE
Detect the entire RATS tag when searching for AddMusicM data

### DIFF
--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1953,7 +1953,7 @@ void tryToCleanAM4Data()
 
 void tryToCleanAMMData()
 {
-	if ((rom.size() % 0x8000 != 0 && rom[0x078200] == 0x53) || (rom.size() % 0x8000 == 0 && rom[0x078000] == 0x53))		// Since RATS tags only need to be in banks 0x10+, a tag here signals AMM usage.
+	if ((rom.size() % 0x8000 != 0 && findRATS(0x078200)) || (rom.size() % 0x8000 == 0 && findRATS(0x078000)))		// Since RATS tags only need to be in banks 0x10+, a tag here signals AMM usage.
 	{
 		if (rom.size() % 0x8000 == 0)
 			printError("AddmusicM ROMs can only be cleaned if they have a header. This does not\napply to any other aspect of the program.", true);

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -393,6 +393,23 @@ int PCToSNES(int addr)
 	return addr;
 }
 
+bool findRATS(int offset)
+{
+	if (rom[offset] != 0x53) {
+		return false;
+	}
+	if (rom[offset+1] != 0x54) {
+		return false;
+	}
+	if (rom[offset+2] != 0x41) {
+		return false;
+	}
+	if (rom[offset+3] != 0x52) {
+		return false;
+	}
+	return true;
+}
+
 int clearRATS(int offset)
 {
 	int size = ((rom[offset + 5] << 8) | rom[offset+4]) + 8;

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -146,6 +146,7 @@ int SNESToPC(int addr);
 int PCToSNES(int addr);
 
 int clearRATS(int PCaddr);
+bool findRATS(int addr);
 
 void addSample(const File &fileName, Music *music, bool important);
 void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint = 0);


### PR DESCRIPTION
Searching for only one byte causes a false positive with sound driver sizes that
have a low byte of $53 in them.

This commit closes #74.