### PR TITLE
Don't trigger note processing if SFX is being played

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -950,6 +950,10 @@ HandleArpeggio:				; Routine that controls all things arpeggio-related.
 .playNote
 	mov	a, !ArpLength+x		; \ Now wait for this many ticks again.
 	mov	!ArpTimeLeft+x, a	; /
+
+	mov	a, $48
+	and	a, $1d
+	bne	.return2
 	
 	mov	a, !PreviousNote+x	; \ Play this note.
 	call	NoteVCMD		; /

--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -957,12 +957,13 @@ HandleArpeggio:				; Routine that controls all things arpeggio-related.
 	mov	a, $48			; \
 	push	a			; |
 	and	a,$0161			; | Key on the current voice (with conditions).
-	and	a,$0162
-	pop	a
-	bne	.return			; |
+	and	a,$0162			; |
+	pop	a			; |
+	bne	.return2		; |
 +
 	or	a, $47			; / Set this voice to be keyed on.
 	mov	$47, a
+.return2
 	ret
 }	
 	


### PR DESCRIPTION
NoteVCMD, if called during arpeggio, interferes with the pitch envelopes of the
SFX by resetting them. Thus, this operation should be skipped, as the note is
not being keyed on anyways.

This merge request closes #50.