### PR TITLE
Rare P-Switch/Starman bug fix

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -606,6 +606,10 @@ HandleSpecialSongs:
 	RTS
 	
 .powMusic
+	lda $1493|!SA1Addr2		;\ KevinM's edit: don't set the song at level end (goal/sphere/boss)
+	ora $1434|!SA1Addr2		;| (keyhole)
+	ora $14AB|!SA1Addr2		;| (bonus game)
+	bne +					;/ This prevents an issue with non-standard goal songs.
 	LDA $1490|!SA1Addr2		; If both P-switch and starman music should be playing
 	BNE .starMusic			;;; just play the star music
 	LDA !PSwitch


### PR DESCRIPTION
Usually AddmusicK keeps setting the P-Switch/Starman song while their respective timers are running, unless the current song number is equal to one of these: !Miss, !GameOver, !StageClear, !IrisOut, !BossClear, !Keyhole. This is an issue if there's an external patch that changes one of these global songs depending on the situation, for example [this patch](https://www.smwcentral.net/?p=section&a=details&id=26321), which changes the goal theme for each level. The cascade of CMP : BEQ will fail, thus setting the P-Switch/Starman song even if it should play the custom goal song. I added a check in the .powMusic code so that this process doesn't happen during level end (either by goal tape, sphere, boss, keyhole or bonus game win), which fixes the problem and it doesn't seem to have unintended side effects.