### PR TITLE
Get rid of fastrom and disable mapper changing errors caused by SA-1 ROM

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -1,5 +1,5 @@
-
-lorom
+;Don't stop program due to changing the mapper multiple times.
+warnings disable W1029
 
 !FreeROM		= $0E8000		; DO NOT TOUCH THESE, otherwise the program won't be able to determine where the data in your ROM is stored!
 ;!Data			= $0E8000		; Data+$0000 = Table of music data pointers 300 bytes long. 
@@ -20,7 +20,7 @@ if !UsingSA1
 	!SA1Addr1 = $3000
 	!SA1Addr2 = $6000
 else
-	fastrom
+	lorom
 	!SA1Addr1 = $0000
 	!SA1Addr2 = $0000
 endif


### PR DESCRIPTION
asar introduced a new kind of warning that caused the program to fail when using
SA-1 base ROMs. In addition, fastrom has been gone since version 1.35 and was
never cleaned up from the code, thus it has been discarded.

This merge request closes #109.