### PR TITLE
Correct stack underflow bug in SPC-generated files

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -94,7 +94,7 @@ endif
 !MusicBackup = $0DDA|!SA1Addr2
 
 
-!DefARAMRet = $044E	; This is the address that the SPC will jump to after uploading a block of data normally.
+!DefARAMRet = $042F	; This is the address that the SPC will jump to after uploading a block of data normally.
 !ExpARAMRet = $0400	; This is the address that the SPC will jump to after uploading a block of data that precedes another block of data (used when uploading multiple blocks).
 !TabARAMRet = $0400	; This is the address that the SPC will jump to after uploading samples.  It changes the sample table address to its correct location in ARAM.
 			; All of these are changed automatically.

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1557,8 +1557,8 @@ void generateSPCs()
 				SPC[0xAF] = '0';
 				SPC[0xB0] = '0';
 
-				SPC[0x25] = programUploadPos & 0xFF;	// Set the PC to the main loop.
-				SPC[0x26] = programUploadPos >> 8;	// The values of the registers (besides stack which is in the file) don't matter.  They're 0 in the base file.
+				SPC[0x25] = mainLoopPos & 0xFF;	// Set the PC to the main loop.
+				SPC[0x26] = mainLoopPos >> 8;	// The values of the registers (besides stack which is in the file) don't matter.  They're 0 in the base file.
 
 				i = backupIndex;
 


### PR DESCRIPTION
Both the C++ side and the SNES side are involved: for the SNES side, the hard-coded location has been updated. For the C++-side, the variable used has been changed for better automation.

The C++ side will probably end up further modified, which in turn will deprecate a command line flag because it will end up completely non-functional as a result (if it hasn't already been made non-functional).

This merge request closes #54.