### PR TITLE
Mark all user-defined samples in music as important

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2613,7 +2613,7 @@ void Music::parseSampleDefinitions()
 			if (extension == ".bnk")
 				addSampleBank(tempstr, this);
 			else if (extension == ".brr")
-				addSample(tempstr, this, false);
+				addSample(tempstr, this, true);
 			else
 				fatalError("The filename for the sample was invalid.  Only \".brr\" and \".bnk\" are allowed.")
 


### PR DESCRIPTION
The user is expecting all user-defined samples to actually be added in to the
final result. Most commonly they're manually taken from the #optimized sample
group without selecting all samples. This is generally happening for ROM
compilation (though with post-filtering afterwards), but it is not happening for
SPC compilation.

This commit closes #121.