### PR TITLE
Import important markers from samples taken from sample groups

### DIFF
--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -494,6 +494,21 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 				return;
 			}
 		}
+		fs::path p1 = "./"+newSample.name;
+		//If the sample in question was taken from a sample group, then use the sample group's important flag instead.
+		for (int i = 0; i < bankDefines.size(); i++)
+		{
+			for (int j = 0; j < bankDefines[i]->samples.size(); j++)
+			{
+				fs::path p2 = "./samples/"+*(bankDefines[i]->samples[j]);
+				if (fs::equivalent(p1, p2))
+				{
+					//Copy the important flag from the sample group definition.
+					newSample.important = bankDefines[i]->importants[j];
+					break;
+				}
+			}
+		}
 	}
 	sampleToIndex[newSample.name] = samples.size();
 	music->mySamples.push_back(samples.size());


### PR DESCRIPTION
The user can define a sample taken straight out of a sample group without taking
the entire sample pack in one go. However, this tends to result in inconsistency
between SPC and ROM compilation as far as what samples are included because of
an external factor (specifically, a song using samples from a sample group
before a song using individually picked samples chooses them). Thus, the default
behavior is now to import the important flag from the group if the sample is
part of a sample group.

This merge request closes #123.