### PR TITLE
Fix regression with SFX noise channels not being set

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -921,9 +921,9 @@ endif
 	jmp	.getMoreSFXData		; / We're done here; get the next SFX command.
 .noise	
 	and	a, #$1f			; \ Noise can only be from #$00 - #$1F	
+	or	(!SFXNoiseChannels), ($18)
 if !noiseFrequencySFXInstanceResolution = !true
 	mov	$01f1+x, a
-	or	(!SFXNoiseChannels), ($18)
 	cmp	!SFXNoiseChannels, $18
 	beq	.noiseNoPrevSFXFrequency
 	call	SetSFXNoise


### PR DESCRIPTION
A regression occurred when noise frequency conflict resolution between SFX
instances was disabled by failing to set the SFX channels to play the noise in
the first place. The rest of the code was functional.

This merge request closes #138.