### PR TITLE
Fix regression caused by using BNK files during sample group check Part 2

### DIFF
--- a/src/AddmusicK/Sample.h
+++ b/src/AddmusicK/Sample.h
@@ -12,13 +12,14 @@ public:
 	bool exists;
 	bool important;			// If a sample is important, then is should never be excluded.
 					// Otherwise, it's only used if the song has an instrument or $E5/$F3 command that is using it.
-
+	bool isBNK; //Samples generated from a BNK file have specific checks omitted from it due to using an auto-generated name.
 
 	Sample(void)
 	{
 		loopPoint = 0;
 		exists = false;
 		important = true;
+		isBNK = false;
 	}
 };
 

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -442,13 +442,11 @@ void addSample(const File &fileName, Music *music, bool important)
 	addSample(temp, actualPath, music, important, false);
 }
 
-void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint)
+void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint, bool isBNK)
 {
 	Sample newSample;
-	if (important)
-		newSample.important = true;
-	else
-		newSample.important = false;
+	newSample.important = important;
+	newSample.isBNK = isBNK;
 
 	if (sample.size() != 0)
 	{
@@ -495,7 +493,7 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 			}
 		}
 		//BNK files don't qualify for the next check. 
-		if (newSample.name.find("__SRCNBANKBRR", 0) == -1) {
+		if (!(newSample.isBNK)) {
 			fs::path p1 = "./"+newSample.name;
 			//If the sample in question was taken from a sample group, then use the sample group's important flag instead.
 			for (int i = 0; i < bankDefines.size(); i++)
@@ -605,7 +603,7 @@ void addSampleBank(const File &fileName, Music *music)
 		char temp[20];
 		sprintf(temp, "__SRCNBANKBRR%04X", bankSampleCount++);
 		tempSample.name = temp;
-		addSample(tempSample.data, tempSample.name, music, true, true, tempSample.loopPoint);
+		addSample(tempSample.data, tempSample.name, music, true, true, tempSample.loopPoint, true);
 	}
 }
 

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -487,7 +487,10 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 		{
 			if (samples[i].data == newSample.data)
 			{
-				sampleToIndex[name] = i;
+				//Don't add samples from BNK files to the sampleToIndex map, because they're not valid filenames.
+				if (!(newSample.isBNK)) {
+					sampleToIndex[name] = i;
+				}
 				music->mySamples.push_back(i);
 				return;
 			}
@@ -511,7 +514,10 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 			}
 		}
 	}
-	sampleToIndex[newSample.name] = samples.size();
+	//Don't add samples from BNK files to the sampleToIndex map, because they're not valid filenames.
+	if (!(newSample.isBNK)) {
+		sampleToIndex[newSample.name] = samples.size();
+	}
 	music->mySamples.push_back(samples.size());
 	samples.push_back(newSample);					// This is a sample we haven't encountered before.  Add it.
 }

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -149,7 +149,7 @@ int clearRATS(int PCaddr);
 bool findRATS(int addr);
 
 void addSample(const File &fileName, Music *music, bool important);
-void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint = 0);
+void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint = 0, bool isBNK = false);
 void addSampleGroup(const File &fileName, Music *music);
 void addSampleBank(const File &fileName, Music *music);
 


### PR DESCRIPTION
Upgraded the check by modifying the Sample class to contain a special variable saying whether it was generated from a BNK file, thus allowing the check to be bypassed without having to check strings.

In addition, the getSample call was wrecking havoc with samples from BNK files due to invalid path errors when checking. Thus, the sampleToIndex variable now prohibits BNK-generated samples from joining to avoid this problem.

This merge request closes #139 again and closes #144.