### PR TITLE
Don't use pitch base fractional multiplier in 1DFA SFX

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1103,6 +1103,8 @@ SetSFXInstrument:
 	mov	a, SFXInstrumentTable+x ; \
 	mov	x, $46			; |
 	mov	$0210+x, a		; / Something to do with pitch...?
+	mov	a, #$00			; \ Disable sub-tuning
+	mov	$02f0+x, a		; /
 	ret
 }
 
@@ -1155,6 +1157,10 @@ SFXTerminateVCMD:
 	db $00
 
 SFXTerminateCh:
+	mov	a, !ChSFXPtrs+1+x
+	bne	+
+	ret
++
 	mov	a, #SFXTerminateVCMD&$ff
 	mov	!ChSFXPtrs+x, a
 	mov	a, #SFXTerminateVCMD>>8


### PR DESCRIPTION
This one has two fixes that combine to stop this problem:
- Don't terminate a SFX sequence if one isn't there
- Zero out the pitch base fractional multiplier when reading SFX instrument

This merge request closes #156.