### PR TITLE
Mark channel used by 1DFA SFX as not being used by P-Switch SFX

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1500,6 +1500,7 @@ L_0A14:
 	
 	call	KeyOffVoices
 	set1	$1d.!1DFASFXChannel		; Turn off channel 7's music
+	clr1	$1b.!1DFASFXChannel		; Turn off channel 7's P-Switch allocation
 	mov	x, #(!1DFASFXChannel*2)
 	jmp	SFXTerminateCh
 ; $01 = 01


### PR DESCRIPTION
SFXTerminateCh normally does that job for us, but when there is no such sequence
there, this part ends up failing to occur. Thus, we add a line of code so that
the P-Switch SFX will always know that the channel got deallocated.

This merge request closes #157.