### PR TITLE
Don't skip the !MaxEchoDelay check in $FA $04 VCMD if EDL is zero

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -824,7 +824,6 @@ SubC_table2:
 ;	
 	
 	call	GetCommandData
-	beq	.modifyEchoDelay
 	cmp	a, !MaxEchoDelay
 	beq	+
 	bcc	+


### PR DESCRIPTION
Turns out this is causing a crash when global songs switch back to local songs.
The cause of the crash is simply not waiting for the echo buffer to finish its
current run, but rather than add a waiting cycle, instead the zero check is
discarded because the echo buffer is set to always run anyways at the current
time.

This commit closes #61.