### PR TITLE
Don't force AM4 songs to always read two digit hex values

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2760,7 +2760,6 @@ int Music::getHex(bool anyLength)
 
 	while (pos < text.size())
 	{
-		if (d >= 2 && songTargetProgram == 1) break;
 		if (d >= 2 && anyLength == false)
 			break;
 


### PR DESCRIPTION
Unfortunately, the #pad command works best with more than two digits. A lookup
tells us that the only place more than two digits are currently accepted is in
the #pad command: everywhere else is coded to read two digits by default. That
renders this check redundant.

This commit closes #176.