### PR TITLE
Unconditionally restore the music's noise frequency when SFX is done

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -682,6 +682,8 @@ endif
 	mov	a, #$00
 	mov	!ChSFXPriority+x, a
 ++
+	mov	a, $0389
+	call	ModifyNoise
 	mov	a, !MusicNoiseChannels
 	and	a, $1a
 	beq	RestoreInstrumentInformation
@@ -689,8 +691,6 @@ endif
 	mov	a, !SFXNoiseChannels
 	tclr	$12, a
 	mov	$13, #$01
-	mov	a, $0389
-	call	ModifyNoise
 	;Restore VxVOL DSP registers of all music noise channels.
 	mov	x, #$00
 	mov	$f2, x


### PR DESCRIPTION
There is a case where no channels will have their volumes zeroed out because
they are overwritten by the SFX that also uses the noise. In these cases, the
music noise frequency must be unconditionally restored, or else the channels
will not be able to be restored in this fashion.

This commit closes #183.