### PR TITLE
Zero out fractional pitch base multiplier in $F3 VCMD

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -600,6 +600,9 @@ MSampleLoad:
 	mov	($10)+y, a		; /
 	call	GetCommandData		; \ 
 	mov	y, #$04			; | Get the pitch multiplier byte.
+	mov	($10)+y, a		; |
+	inc	y			; | Zero out pitch sub-multiplier.
+	mov	a, #$00			; |
 	mov	($10)+y, a		; /
 	jmp	UpdateInstr
 }


### PR DESCRIPTION
AddmusicM's $F3 VCMD was not properly updated to account for the pitch base
fractional multiplier being present, which in turn was causing complications for
those songs.

This merge request closes #191.