### PR TITLE
Have $FF actually play the last note endlessly

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -814,15 +814,13 @@ endif
 	beq	.instrumentCommand	; / $DA is the instrument command.
 	cmp	a, #$ff			; \ 
 	bne	.playNote		; / Play a note.
-	mov	y, #$03			; Move back three bytes.
-	;mov	x, $46			; \
--	mov	a, !ChSFXPtrs+x		; |
+	mov	a, !ChSFXPtrs+x		; \ Move back one byte.
 	bne	+			; |
-	dec	!ChSFXPtrs+1+x		; | #$FF is the loop the last note command.
+	dec	!ChSFXPtrs+1+x		; |
 +					; |
 	dec	!ChSFXPtrs+x		; |
-	dbnz	y, -
-	bra	.getMoreSFXData		; /
+	mov	a, $18			; | #$FF is the loop the last note command.
+	bra	.keyOnNote		; /
 ; other $80+
 .loopSFX
 	mov	a, !ChSFXPtrBackup+1+x	; \
@@ -837,10 +835,10 @@ endif
 	push	a
 	mov	a, !InRest+x
 	pop	a
-	beq	+
+	beq	.keyOnNote
 	call	KeyOffVoices
 	bra	.setNoteLength
-+
+.keyOnNote
 	call	KeyOnVoices		; Key on the voice.
 .setNoteLength
 	mov	a, !ChSFXNoteTimerBackup+x	


### PR DESCRIPTION
Turns out other that other than having to rewind a byte anyways, all of the
parameters that this VCMD would theoretically need (except for the note value,
which would simply have the save VxPITCH value as before) in order to endlessly
play the last note, length and all, are actually already stored away and are
ready to use on the fly. Thus, instead of fetching the bytes for the last note
and having to scan backwards for the last valid note ID (that would involve a
lot of ID checking going backwards to make sure we don't mistake it for a VCMD),
we instead simply take the saved data from the last note processed and use that
instead.

This merge request closes #75.