### PR TITLE
Modify !NCKValue to prevent FLG registers from being overwritten

### DIFF
--- a/1DF9/11 Pause (old).txt
+++ b/1DF9/11 Pause (old).txt
@@ -10,7 +10,8 @@ $E0 $FF $DA $02 $0C $54 $B4 $B0 $B4 $18 $B0 #jsr changePause1
 	inc a
 	mov !PauseMusic, a
 	
-	mov $f2, #$6c			;\ Set the mute flag.
-	or  $f3, #$40			;/
+	or  !NCKValue, #$40	; Set the mute flag.
+	;ModifyNoise, called when restoring the noise frequency, will handle
+	;setting the FLG DSP register.
 	ret
 }

--- a/1DF9/12 Unpause (old).txt
+++ b/1DF9/12 Unpause (old).txt
@@ -8,7 +8,8 @@ $E0 $FF #jsr changePause $DA $02 $0C $54 $B4 $B0 $B4 $18 $B0
 	mov a, #$00
 	mov !PauseMusic, a
 	
-	mov $f2, #$6c			;\ Unset the mute flag.
-	and $f3, #$bf			;/
+	and !NCKValue, #$bf		; Unset the mute flag.
+	mov a, !NCKValue
+	call ModifyNoise
 	ret
 }

--- a/1DF9/12 Unpause (silent) (old).txt
+++ b/1DF9/12 Unpause (silent) (old).txt
@@ -11,8 +11,9 @@ $E0 $FF #jsr changePause
 	mov $f2, #$5c		; \ Key off voices
 	mov $f3, #$ff		; / (so the music doesn't restart playing when using start+select)
 	
-	mov $f2, #$6c		;\ Unset the mute flag.
-	and $f3, #$bf		;/
+	and !NCKValue, #$bf		; Unset the mute flag.
+	mov a, !NCKValue
+	call ModifyNoise
 
 	mov $f2, #$2c		;\
 	mov $f3, #$00		;| Mute echo.

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1613,8 +1613,9 @@ UnpauseMusic:
 	mov a, #$00
 	mov !PauseMusic, a
 .unsetMute:
-	mov $f2, #$6c			;\ Unset the mute flag.
-	and $f3, #$bf			;/
+	and !NCKValue, #$bf		; Unset the mute flag.
+	mov a, !NCKValue
+	call ModifyNoise
 
 	mov a, !SpeedUpBackUp	;\
 	mov $0387, a			;/ Restore the tempo.
@@ -1761,8 +1762,9 @@ PauseMusic:
 	inc a
 	mov !PauseMusic, a
 	
-	mov $f2, #$6c			;\ Set the mute flag.
-	or  $f3, #$40			;/
+	or  !NCKValue, #$40	; Set the mute flag.
+	;ModifyNoise, called when restoring the noise frequency, will handle
+	;setting the FLG DSP register.
 	ret
 
 if !noSFX = !false	


### PR DESCRIPTION
The noise SFX frequency conflict resolution code, specifically the one that
restores the music noise frequency, is causing problems with the pause SFX by
overwriting the mute flag on the FLG register. Therefore, we have to actually
set the flag in question on the mirror as well.

For the pause SFX, this actually makes directly setting the FLG register
beforehand redunant, since it happens anyways at the end. For the both unpause
SFX variants, setting the FLG DSP register is not optional, and thus we call
ModifyNoise right then and there to get that set up.

This merge request closes #194.