### PR TITLE
Don't force percussion notes on Addmusic405 and AddmusicM ports on Ch6&Ch7

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2080,7 +2080,7 @@ void Music::parseNote()
 		{
 			i = 0xD0 + (instrument[channel] - 21);
 
-			if ((channel == 6 || channel == 7 || (channel == 8 && (prevChannel == 6 || prevChannel == 7))) == false)	// If this is not a SFX channel,
+			if (songTargetProgram != 0 || ((channel == 6 || channel == 7 || (channel == 8 && (prevChannel == 6 || prevChannel == 7))) == false))	// If this is not a SFX channel,
 				instrument[channel] = 0xFF;										// Then don't force the drum pitch on every note.
 		}
 	}


### PR DESCRIPTION
This wasn't the behavior of the original programs, and thus counts as a
conversion bug. The correct behavior is to only do so on the first note:
AddmusicK added some code that always outputs percussion notes on #6 and #7, but
this conflicts with the original behavior on AM405 and AMM. So the code now only
applies to when AddmusicK itself is the target program.

This commit closes #198.