### PR TITLE
Fix fatal bug with lowest non-zero channel number with Addmusic405 songs

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -390,6 +390,26 @@ void Music::init()
 		else
 			ignoreTuning[z] = false;
 	}
+
+	if (songTargetProgram == 1) {
+		//If any channel markers exist, set the channel number to the earliest channel found.
+		if (text.find("#0") != -1)
+			channel = 0, prevChannel = 0;
+		else if (text.find("#1") != -1)
+			channel = 1, prevChannel = 1;
+		else if (text.find("#2") != -1)
+			channel = 2, prevChannel = 2;
+		else if (text.find("#3") != -1)
+			channel = 3, prevChannel = 3;
+		else if (text.find("#4") != -1)
+			channel = 4, prevChannel = 4;
+		else if (text.find("#5") != -1)
+			channel = 5, prevChannel = 5;
+		else if (text.find("#6") != -1)
+			channel = 6, prevChannel = 6;
+		else if (text.find("#7") != -1)
+			channel = 7, prevChannel = 7;
+	}
 }
 
 void Music::compile()


### PR DESCRIPTION
The phrase end marker was being generated for Ch0 even if the channel was never
defined in the first place. For Addmusic405 songs, this is a fatal bug, since it
causes the sound driver to stop in its tracks as it endlessly restarts
the phrase. The scope has been limited to Addmusic405 for now: other targets
will be handled on a case-by-case basis if they are encountered, and AMK itself
will not have this applied to it for consistency's sake.

This merge request closes #202.