### PR TITLE
Stop 1DFA SFX from processing when 1DF9/1DFC SFX play on same channel

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1505,14 +1505,32 @@ endif
 	push	a
 	mov	a, !ChSFXPtrs+1+x
 	pop	a
-	beq	.sfxAllocAllowed
+	beq	.checkAPU1SFX
 
 	cmp	a, !ChSFXPriority+x
-	bcs	.sfxAllocAllowed
+	bcs	.checkAPU1SFX
 
 .noSFXOverwrite
 	pop	a
 	ret
+
+.checkAPU1SFX
+	;Check and see if APU1 SFX is playing there via detecting $1D.
+	;APU1 SFX is playing if APU0/APU3 SFX sequence data is not playing,
+	;but $1D has a voice bit set.
+	push	a
+	mov	a, $1d
+	and	a, $10
+	pop	a
+	beq	.sfxAllocAllowed
+
+	;Stop all APU1 SFX on the same channel.
+	push	a
+	mov	a, #$00
+	mov	$05, a
+	mov	$1c, a
+	mov	$0383, a
+	pop	a
 
 .sfxAllocAllowed
 	mov	!ChSFXPriority+x, a


### PR DESCRIPTION
There is an edge case when 1DFA SFX starts playing, only for 1DF9/1DFC SFX to
play immediately afterwards, which can cause some interference for the SFX
sequences for the latter, especially since the priority checks don't mark it for
overwriting.

This merge request closes #207.