### PR TITLE
Don't factor in triplets when calculating the default note length

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -573,7 +573,7 @@ void Music::parseLDirective()
 	else if (i == -1) error("Error parsing \"l\" directive.")
 	else if (i < 1 || i > 192) error("Illegal value for \"l\" directive.")
 	else {defaultNoteLength = 192 / i;}
-	defaultNoteLength = getNoteLengthModifier(defaultNoteLength);
+	defaultNoteLength = getNoteLengthModifier(defaultNoteLength, false);
 }
 void Music::parseGlobalVolumeCommand()
 {
@@ -2814,10 +2814,10 @@ int Music::getNoteLength(int i)
 	else if (i < 1 || i > 192) i = defaultNoteLength;
 	else i = 192 / i;
 
-	return getNoteLengthModifier(i);
+	return getNoteLengthModifier(i, true);
 }
 
-int Music::getNoteLengthModifier(int i) {
+int Music::getNoteLengthModifier(int i , bool allowTriplet) {
 	int frac = i;
 
 	int times = 0;
@@ -2830,7 +2830,7 @@ int Music::getNoteLengthModifier(int i) {
 		if (times == 2 && songTargetProgram == 1) break;	// AM4 only allows two dots for whatever reason.
 	}
 	//}
-	if (triplet)
+	if (triplet && allowTriplet)
 		i = (int)floor(((double)i * 2.0 / 3.0) + 0.5);
 	return i;
 }

--- a/src/AddmusicK/Music.h
+++ b/src/AddmusicK/Music.h
@@ -167,7 +167,7 @@ private:
 	int getHex(bool anyLength = false);
 	int getPitch(int j);
 	int getNoteLength(int);
-	int getNoteLengthModifier(int);
+	int getNoteLengthModifier(int, bool);
 
 	bool guessLength;
 	int resizedChannel;


### PR DESCRIPTION
Triplets were previously de-facto ignored by the default note length, and
factoring them in causes them to be calculated twice by mistake. Because
triplets are temporary modifiers due to being defined as a section, unlike
dotted notes, they don't need to permanently modify the default note length.

This merge request closes #214 and mentions #1 due to reverting a change that was
breaking existing cases.