### PR TITLE
Use hard-coded transposition for built-in instruments on AddmusicM

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -802,11 +802,13 @@ void Music::parseInstrumentCommand()
 	if (optimizeSampleUsage)
 		usedSamples[instrToSample[i]] = true;
 
-	//hTranspose = 0;
-	//usingHTranspose = false;
 	instrument[channel] = i;
 	//if (htranspose[i] == true)
-	//transposeMap[instrument[channel]] = ::tmpTrans[instrument[channel]];
+	if (songTargetProgram == 2 && i < 19) {
+		hTranspose = 0;
+		usingHTranspose = false;
+		transposeMap[instrument[channel]] = ::tmpTrans[instrument[channel]];
+	}
 }
 
 void Music::parseOpenParenCommand()


### PR DESCRIPTION
AddmusicM overwrites the h values by default when handling transposition, which
previously was not handled correctly in AddmusicK. This is only a problem with
AddmusicM due to it implementing a new transposition command during compilation:
Addmusic405 uses a per-track transposition command that only affects the SPC700
side, and Addmusic Java notes, but never implements, a transposition command.

This merge request closes #218.