### PR TITLE
Correct channel unmuting problem + optimize Yoshi Drum handling code

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -630,9 +630,7 @@ SubC_0:
 SubC_00:
 	call	HandleYoshiDrums		; Handle the Yoshi drums.
 	mov	a,#$01
-	push	a
-	mov	a,$6e
-	pop	a
+	cmp	$6e, #$00
 	beq	SubC_02
 
 SubC_01:

--- a/readme_files/aram_map.html
+++ b/readme_files/aram_map.html
@@ -801,13 +801,8 @@ Romi's Addmusic (Addmusic404)'s custom code used no new memory locations, and th
 				<td>AddmusicK</td>
 			</tr>
 			<tr>
-				<td>$0385</td>
+				<td>$0385-$0386</td>
 				<td colspan="2"><div style="text-align:center; font-weight: bold;">Unused.</div></td>
-			</tr>
-			<tr>
-				<td>$0386</td>
-				<td>Yoshi Drum switch, set via CPUIO1 commands.</td>
-				<td>Vanilla</td>
 			</tr>
 			<tr>
 				<td>$0387</td>
@@ -1246,6 +1241,11 @@ Romi's Addmusic (Addmusic404)'s custom code used no new memory locations, and th
 				<td>$0385</td>
 				<td>Saved note duration for CPUIO3 SFX.</td>
 				<td>Varies by voice ID (going by vanilla default (#6), it's $03DD, and going by AMK default (#7), it's $03DF)</td>
+			</tr>
+			<tr>
+				<td>$0386</td>
+				<td>Yoshi Drum switch, set via CPUIO1 commands.</td>
+				<td>N/A (Turned into an opcode switch after AddmusicK 1.0.8, and thus embedded into the code)</td>
 			</tr>
 			<tr>
 				<td>$0389</td>


### PR DESCRIPTION
First off, the mute flag is now completely cleared prior to conditionally
setting any Yoshi Drum bits. This means that a section of commented out code is
included in case any external code wants to set any additional flags: they just
need to send it over to the embedded memory location in question, and then
uncomment a couple a lines of code.

Secondly, some code optimization related to Yoshi Drum handling was done. $0386
is officially losing its usage due to being turned into an opcode switch
depending on whether the Yoshi Drums are on or off: thus, the memory location is
now free.

This merge request closes #230.