### PR TITLE
Fix graphical glitch during submap transitions

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -336,6 +336,13 @@ endif
 
 	LDA #$FF		; Send this as early as possible
 	STA $2141		;
+
+	LDA $0100|!SA1Addr2	;\     Check Gamemode.
+    	CMP #$0E		; | If on the Overworld,
+	BNE +			; |    
+	WAI			;/     then wait for an interrupt to prevent garbage during Submap transitions.
+    
++
 	
 	SEI
 	


### PR DESCRIPTION
This fixes a graphical glitch during submap transitions by executing a WAI
opcode to wait for an interrupt first before disabling interrupts in order to
safely load a song.

Code contributed by Barrels O' Fun from the SMWCentral server.

This merge request closes #233.