### PR TITLE
Revamp modifying the ESA with the EDL

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -483,29 +483,19 @@ WaitForDelay:				; This stalls the SPC for the correct amount of time depending 
 	inc	$15
 	bne	-
 	
-+	ret
-	
-GetBufferAddress:
-	xcn
-	beq	+
-	and	a, #$F0
-	lsr	a
-	mov	$14, #$00
-	mov	$15, a
-	movw	ya, $0e
-	subw	ya, $14		
-	ret				; 
-+
-	mov	a, #$fc			; \ A delay of 0 needs 4 bytes for no adequately explained reason.
-	mov	y, #$ff			; /
-	ret
-	
++	ret	
 	
 ModifyEchoDelay:			; a should contain the requested delay.
 	mov	$10, !NCKValue
+	and	a, #$0F
 	push	a			; Save the requested delay.
-	call	GetBufferAddress
-	push	y
+	beq	+
+	xcn	a			; Get the buffer address.
+	lsr	a
+	dec	a
++
+	eor	a, #$FF
+	push	a
 
 	mov	!NCKValue, #$60
 	call	SetFLGFromNCKValue

--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -480,8 +480,8 @@ ModifyEchoDelay:			; a should contain the requested delay.  Normally only called
 	eor	a, #$FF
 	push	a
 
-	or	!NCKValue, #$60
-	call	SetFLGFromNCKValue
+	mov	$f2, #$6c
+	or	$f3, #$60
 
 	mov	$f2, #$7d
 	mov	a, $f3
@@ -516,8 +516,6 @@ ModifyEchoDelay:			; a should contain the requested delay.  Normally only called
 	inc	$15
 	bne	-
 +	
-	
-	and	!NCKValue, #$1f
 	jmp	SetFLGFromNCKValue
 
 SetEDLVarDSP:
@@ -781,6 +779,7 @@ SubC_table2:
 	;Don't skip again until !MaxEchoDelay is reset.
 	mov	SubC_table2_reserveBuffer_zeroEDLGate+1, a
 ..modifyEchoDelay
+	clr1	!NCKValue.5
 	jmp	ModifyEchoDelay
 	
 .gainRest

--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -486,7 +486,6 @@ WaitForDelay:				; This stalls the SPC for the correct amount of time depending 
 +	ret	
 	
 ModifyEchoDelay:			; a should contain the requested delay.
-	mov	$10, !NCKValue
 	and	a, #$0F
 	push	a			; Save the requested delay.
 	beq	+
@@ -497,7 +496,7 @@ ModifyEchoDelay:			; a should contain the requested delay.
 	eor	a, #$FF
 	push	a
 
-	mov	!NCKValue, #$60
+	or	!NCKValue, #$60
 	call	SetFLGFromNCKValue
 	
 	pop	y			; \
@@ -508,19 +507,15 @@ ModifyEchoDelay:			; a should contain the requested delay.
 	call	SetEDLVarDSP		; Write the new delay.
 	mov	!MaxEchoDelay, a
 	
-	call	WaitForDelay		; > Wait until we can be sure that the echo buffer has been moved safely.
+	call	WaitForDelay		; > Wait until we can be sure that the echo buffer has been moved safely.	
 
-	
-	mov	!NCKValue, #$40
+	clr1	!NCKValue.5
 	call	SetFLGFromNCKValue
-	
-	
 	
 	call	WaitForDelay		; > Clear out the RAM associated with the new echo buffer.  This way we avoid noise from whatever data was there before.
 	
-	mov	!NCKValue, #$00
-	mov	a, $10
-	jmp	ModifyNoise
+	and	!NCKValue, #$1f
+	jmp	SetFLGFromNCKValue
 
 SetEDLVarDSP:
 	mov	!EchoDelay, a		; \

--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -498,6 +498,19 @@ ModifyEchoDelay:			; a should contain the requested delay.
 
 	or	!NCKValue, #$60
 	call	SetFLGFromNCKValue
+
+	mov	$f2, #$7d
+	mov	a, $f3
+	and	a, #$0f
+	beq	+
+	mov	$f3, #$00		; Wait for the echo buffer to be "captured" in a four byte area at the beginning before modifying the ESA and EDL DSP registers.
+	xcn	a			; This ensures it can be safely reallocated without risking overwriting the program.
+	lsr	a			; This requires waiting for at least the amount of time it takes for the old EDL value to complete one buffer write loop.
+	mov	$14, #$00
+	mov	$15, a
+-	dbnz	$14, -
+	dbnz	$15, -
++
 	
 	pop	y			; \
 	mov	$f2, #$6d		; | Write the new buffer address.

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -125,7 +125,7 @@ incsrc "UserDefines.asm"
 !PlayingVoices = $0382		; Each bit is set to 1 if there's currently a voice playing on that channel (either by music or SFX).
 !SpeedUpBackUp = $0384		; Used to restore the speed after pausing the music.
 
-
+!reserveBufferZeroEDLGateDistance = SubC_table2_reserveBuffer_zeroEDL-SubC_table2_reserveBuffer_zeroEDLGate-2
 
 !ProtectSFX6 = $038a		; If set, sound effects cannot start on channel #6 (but they can keep playing if they've already started)
 !ProtectSFX7 = $038b		; If set, sound effects cannot start on channel #7 (but they can keep playing if they've already started)
@@ -1688,6 +1688,8 @@ if !noSFX = !false
 	mov	$1d, a
 endif
 	mov	!MaxEchoDelay, a	;
+	mov	a, #!reserveBufferZeroEDLGateDistance
+	mov	SubC_table2_reserveBuffer_zeroEDLGate+1, a
 	call	EffectModifier
 
 	jmp	L_12F2             ; do standardish SPC transfer                                ;ERROR


### PR DESCRIPTION
In addition to setting up a zero case (this originally always existed, but for this case, it is now set up as a gate that only resets upon loading another local song to avoid retriggering it when switching between global songs, thus avoiding regressing from #61), this also revamps the way the ESA is set up so that it can handle EDL values less than the value currently in use (meaning the ESA is moved closer to the end of ARAM, normally risking an overflow if not done properly), as well as avoid any unexpected pitfalls with not waiting before modifying the ESA and EDL.

This merge request closes #237.