### PR TITLE
Force a note that gets parsed to be a lowercase letter

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2045,7 +2045,7 @@ void Music::parseHexCommand()
 }
 void Music::parseNote()
 {
-	j = text[pos];
+	j = tolower(text[pos]);
 	pos++;
 
 	if (inRemoteDefinition)


### PR DESCRIPTION
Uppercase letters that end up here end up reading outside the bounds of an
array when reading the pitch. Therefore, the note being parsed must be forced to
lowercase to avoid undefined behavior on compilation.

This merge request closes #246.