### PR TITLE
Use standard SFX sequence data for CPUIO1 SFX

### DIFF
--- a/asm/UserDefines.asm
+++ b/asm/UserDefines.asm
@@ -155,6 +155,17 @@ includeonce
 
 ;=======================================
 ;---------------
+!useSFXSequenceFor1DFASFX = !true
+
+;Default setting: !true
+;Vanilla SMW setting: !false
+;---------------
+; Replaces the hard-coded 1DFA SFX with a standard sequence used for 1DF9
+; and 1DFB.
+;=======================================
+
+;=======================================
+;---------------
 !PSwitchSFXCh0ID = 5
 
 ;Default setting: 5

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -705,9 +705,11 @@ EndSFX:
 				
 	
 	mov	a, $18
+if !useSFXSequenceFor1DFASFX = !false
 	bbc!1DFASFXChannel	$18, +
 	cmp	$1c, #$00
 	bne	++
+endif
 +					; \
 	tclr	$1d, a			; | Clear the bit of $1d that this SFX corresponds to.
 ++
@@ -723,9 +725,11 @@ if !noiseFrequencySFXInstanceResolution = !true
 endif
 .restoreMusicNoise:
 	mov	$1f, #$00
+if !useSFXSequenceFor1DFASFX = !false
 	bbc!1DFASFXChannel	$18, +
 	mov	a, $1c
 	bne	++
+endif
 +
 	mov	a, #$00
 	mov	!ChSFXPriority+x, a
@@ -1514,10 +1518,26 @@ ProcessSFXInput:				; X = channel number * 2 to play a potential SFX on, y = inp
 	asl	a				; |
 	mov	y, a				; | Y = SFX * 2, index to a table.
 	pop	a				; | If a is 0, then the table we load from table 1.
-	cmp	a, #$00				; | Otherwise, we load from table 2.
-	push	a
-	beq	+				; /
+	push	a				;
+	cmp	a, #$01				; | Otherwise, we load from table 2.
+	bcc	.loadFromSFXTable0		; /
+if !useSFXSequenceFor1DFASFX = !true
+	bne	.loadFromSFXTable1
+	cmp	y, #$04*2
+	beq	.useAPU1GirderSFX
+	;cmp	y, #$01*2
+	;beq	.useAPU1JumpSFX
+.useAPU1JumpSFX
+	mov	a, #APU1JumpSFXSequence&$FF
+	mov	y, #APU1JumpSFXSequence>>8&$FF
+	bra	.gottenPointerNoPop
+.useAPU1GirderSFX
+	mov	a, #APU1GirderClickSFXSequence&$FF
+	mov	y, #APU1GirderClickSFXSequence>>8&$FF
+	bra	.gottenPointerNoPop
+endif
 						;
+.loadFromSFXTable1				;
 if !PSwitchIsSFX = !true
 	cmp	$03, #$81			;
 	bcs	.PSwitchSFX
@@ -1527,7 +1547,7 @@ endif
 	mov	a, SFXTable1-2+y		; |
 	bra	.gottenPointer			;
 						;
-+						;
+.loadFromSFXTable0				;
 	mov	a, SFXTable0-1+y		; \
 	push	a				; |
 	mov	a, SFXTable0-2+y		; /
@@ -1544,6 +1564,7 @@ if !PSwitchIsSFX = !true
 endif	
 .gottenPointer
 	pop	y
+.gottenPointerNoPop
 	movw	$14, ya
 
 ;Check SFX priority.
@@ -1573,6 +1594,7 @@ endif
 	ret
 
 .checkAPU1SFX
+if !useSFXSequenceFor1DFASFX = !false
 	;Check and see if APU1 SFX is playing there via detecting $1D.
 	;APU1 SFX is playing if APU0/APU3 SFX sequence data is not playing,
 	;but $1D has a voice bit set.
@@ -1588,6 +1610,7 @@ endif
 	mov	$05, a
 	mov	$1c, a
 	pop	a
+endif
 
 .sfxAllocAllowed
 	mov	!ChSFXPriority+x, a
@@ -1692,7 +1715,7 @@ DisableYoshiDrums:				; And disable them.
 	mov	a, #$0E			;TSET opcode
 +
 	mov	HandleYoshiDrums_drumSet, a
-if !noSFX = !false
+if !useSFXSequenceFor1DFASFX = !false && !noSFX = !false
 	call	HandleYoshiDrums
 	bra	ProcessAPU1SFX
 else
@@ -1732,8 +1755,12 @@ ForceSFXEchoOff:
 ForceSFXEchoOn:
 	mov	a, #$ff
 +	mov	!SFXEchoChannels, a
+if !useSFXSequenceFor1DFASFX = !false
 	call	EffectModifier
 	bra	ProcessAPU1SFX
+else
+	jmp	EffectModifier
+endif
 endif
 ProcessAPU1Input:				; Input from SMW $1DFA
 	mov	a, $01
@@ -1774,6 +1801,7 @@ if !noSFX = !false
 	beq	CheckAPU1SFXPriority
 ;
 ProcessAPU1SFX:
+if !useSFXSequenceFor1DFASFX = !false
 	mov	a, $05		; 
 	cmp	a, #$01		; \ If the currently playing SFX is the jump SFX
 	beq	L_0A51		; / Then process that.
@@ -1783,12 +1811,19 @@ L_0A0D:
 	ret
 L_0A11:
 	jmp	L_0B08
+else
+	ret
+endif
 
 PlayPauseSFX:
 	mov	a, #$11
 	mov	$00, a
 	mov	!ProtectSFX6, a
+if !useSFXSequenceFor1DFASFX = !false
 	bra	ProcessAPU1SFX
+else
+	ret
+endif
 
 PlayUnpauseSilentSFX:
 	mov	a, #$2C
@@ -1800,7 +1835,11 @@ PlayUnpauseSFX:
 	mov	a, #$00
 	mov	!ProtectSFX6, a
 	;mov	$08, #$00
-	bra ProcessAPU1SFX
+if !useSFXSequenceFor1DFASFX = !false
+	bra	ProcessAPU1SFX
+else
+	ret
+endif
 endif
 
 PauseMusic:
@@ -1819,6 +1858,12 @@ PauseMusic:
 
 if !noSFX = !false	
 CheckAPU1SFXPriority:
+if !useSFXSequenceFor1DFASFX = !true
+	mov	x, #(!1DFASFXChannel*2)
+	mov	y, #$01
+	mov	$10, #(1<<!1DFASFXChannel)
+	jmp	ProcessSFXInput
+else
 	mov	y, a
 	;mov	y, #$00		;Default priority
 	cmp	a, #$01
@@ -1951,6 +1996,7 @@ Quick1DFAMonoVolDSPWritesWKON:
 	movw	$f2, ya
 	mov	a, #(1<<!1DFASFXChannel)
 	jmp	KeyOnVoices
+endif
 endif
 				; Call this routine to play the song currently in A.
 PlaySong:
@@ -3239,6 +3285,17 @@ GetSampleTableLocation:
 	
 
 if !noSFX = !false
+if !useSFXSequenceFor1DFASFX = !true
+APU1JumpSFXSequence:
+	db $E0
+	db !JumpSFX1DFAPriority
+	db $DA,$08,$05,$38,$DD,$B2,$00,$05,$B5,$2A,$EB,$01,$12,$B9,$00
+APU1GirderClickSFXSequence:
+	db $E0
+	db !GirderSFX1DFAPriority
+	db $DA,$07,$0C,$28,$A4,$A4,$00
+endif
+
 	SFXTable0:
 	SFXTable1:
 endif

--- a/readme_files/aram_map.html
+++ b/readme_files/aram_map.html
@@ -102,7 +102,7 @@ Romi's Addmusic (Addmusic404)'s custom code used no new memory locations, and th
 			<tr>
 				<td>$1C</td>
 				<td>Tick counter for CPUIO1 SFX.</td>
-				<td>!noSFX = false</td>
+				<td>!noSFX = false<br>!useSFXSequenceFor1DFASFX = !false</td>
 				<td>Vanilla</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
For big savings, we can have the standard SFX sequence format take over. The
original code is still present both for historical reference... and in case
someone prefers the hardcoded approach or finds a problem when using the SFX
sequence replicas. The default is now set to use these sequences due to the
amount of memory this saves.

This merge request closes #249.