### PR TITLE
Output warnings for use of non-native hex commands from past Addmusics

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -87,6 +87,8 @@ static bool tempoDefined;
 
 static bool sortReplacements;
 static bool manualNoteWarning;
+static bool nonNativeHexWarning;
+static bool nonNativeCmdWarning;
 
 static bool channelDefined;
 //static int am4silence;			// Used to keep track of the brief silence at the start of am4 songs.
@@ -174,6 +176,8 @@ void Music::init()
 	prevChannel = 0;
 	openTextFile((std::string)"music/" + name, text);
 	manualNoteWarning = true;
+	nonNativeHexWarning = true;
+	nonNativeCmdWarning = true;
 	tempoDefined = false;
 	//am4silence = 0;
 	//songVersionIdentified = false;
@@ -1532,6 +1536,14 @@ void Music::parseHexCommand()
 		{
 			//validateTremolo = true;
 			currentHex = i;
+			if (i > 0xF2 && songTargetProgram == 1 && nonNativeHexWarning) {
+				printWarning("WARNING: A hex command was used which is not native to AddMusic405.\nDid you mean: #amm", name, line);
+				nonNativeHexWarning = false;
+			}
+			if (i > 0xFA && songTargetProgram == 2 && nonNativeHexWarning) {
+				printWarning("WARNING: A hex command was used which is not native to AddMusicM.\nDid you mean: #amk 1", name, line);
+				nonNativeHexWarning = false;
+			}
 			if (i < 0xDA)
 			{
 				if (manualNoteWarning)
@@ -1663,6 +1675,12 @@ void Music::parseHexCommand()
 		else
 		{
 			hexLeft -= 1;
+			
+			if (hexLeft == 0 && currentHex == 0xF4 && i >= 0x07 && songTargetProgram == 2 && nonNativeHexWarning) {
+				printWarning("WARNING: A hex command was used which is not native to AddMusicM.\nDid you mean: #amk 1", name, line);
+				nonNativeHexWarning = false;
+			}
+			
 			// If we're on the last hex value for $E5 and this isn't an AMK song, then do some special stuff regarding tremolo.
 			// AMK doesn't use $E5 for the tremolo command or sample loading, so it has to emulate them.
 			if (hexLeft == 2 && currentHex == 0xE5 && songTargetProgram == 1/*validateTremolo*/)
@@ -2199,6 +2217,10 @@ void Music::parseNote()
 }
 void Music::parseHDirective()
 {
+	if (songTargetProgram == 1) {
+		printWarning("WARNING: A command was used which is not native to AddMusic405.\nDid you mean: #amm", name, line);
+		nonNativeCmdWarning = false;
+	}
 	pos++;
 	//bool negative = false;
 

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -1681,6 +1681,12 @@ void Music::parseHexCommand()
 				nonNativeHexWarning = false;
 			}
 			
+			if (hexLeft == 1 && currentHex == 0xFA && songTargetProgram == 2)
+			{
+				hexLeft = 0;
+				error("This histortical AddmusicM hex command has not yet been implemented into AddmusicK.");
+			}
+			
 			// If we're on the last hex value for $E5 and this isn't an AMK song, then do some special stuff regarding tremolo.
 			// AMK doesn't use $E5 for the tremolo command or sample loading, so it has to emulate them.
 			if (hexLeft == 2 && currentHex == 0xE5 && songTargetProgram == 1/*validateTremolo*/)


### PR DESCRIPTION
These are not going to be pre-processed. They also give out a suggestion on
which one might be the correct one (in the case of #amk 1, it's because the user
could be in the middle of a conversion from #amm or #am4 and forgot to change
the parser flag).

This merge request mentions #242. The main reason why it doesn't close it is if something else pops up... and yes, this merge request also turns using the $FA VCMD in AddmusicM into an error. See #38 for extra details.