### PR TITLE
Correct lowest note pitch value supported

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2092,7 +2092,7 @@ void Music::parseNote()
 		}
 
 
-		if (i < 0)
+		if (i < 0x80)
 		{
 			error("Note's pitch was too low.")
 				i = 0xC7;


### PR DESCRIPTION
The value being checked here was zero where it should have been $80. This is
because values lower than $80 imply a note duration instead and/or quantization.

This merge request closes #255.