### PR TITLE
Fix build error on Linux GCC

### DIFF
--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <map>
 #include <stack>
+#include <algorithm>
 
 #include "fs.h"		// // //
 


### PR DESCRIPTION
This adds `#include <algorithm>` to `src/AddmusicK/globals.cpp`, to fix the compilation of `std::replace()`.

I assume the original code compiled fine on other machines, because another `#include` indirectly included `<algorithm>` on some machines, but not on mine.