### PR TITLE
Auto-generate a RET before PauseMusic

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1839,6 +1839,8 @@ if !useSFXSequenceFor1DFASFX = !false
 else
 	ret
 endif
+else
+	ret
 endif
 
 PauseMusic:


### PR DESCRIPTION
This was properly handled outside of the master branch in a few cases, but was
accidentally omitted where it mattered the most, breaking !noSFX by having pause
fire during polling, meaning the music can never play.

This merge request closes #266.