### PR TITLE
Fix C++ crash with zero global songs, while avoiding song 0

### DIFF
--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -226,8 +226,8 @@ int main(int argc, char* argv[]) try		// // //
 	{
 		// We start loading CLI songs from highestGlobalSong + 1. If no global songs are
 		// present, highestGlobalSong = 0 and we start loading songs from slot 1. We
-		// must leave slot 0 empty, because the SPC driver treats song 0 as "repeat
-		// current song" rather than a song number, making songs in slot 0 unplayable.
+		// leave slot 0 empty, to match the SNES driver which treats song 0 as "repeat
+		// current song" rather than a song number, and can't send it to the SPC.
 		int firstLocalSong = highestGlobalSong + 1;
 
 		// Unset local songs loaded from Addmusic_list.txt.

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -230,7 +230,7 @@ int main(int argc, char* argv[]) try		// // //
 
 		for (int i = 0; i < textFilesToCompile.size(); i++)
 		{
-			if (highestGlobalSong + i >= 256)
+			if (highestGlobalSong + 1 + i >= 256)
 				printError("Error: The total number of requested music files to compile exceeded 255.", true);
 			musics[highestGlobalSong + 1 + i].exists = true;
 			musics[highestGlobalSong + 1 + i].name = textFilesToCompile[i];

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -241,7 +241,6 @@ int main(int argc, char* argv[]) try		// // //
 				printError("Error: The total number of requested music files to compile exceeded 255.", true);
 			musics[firstLocalSong + i].exists = true;
 			musics[firstLocalSong + i].name = textFilesToCompile[i];
-			openTextFile((std::string("music/") + musics[firstLocalSong + i].name), musics[firstLocalSong + i].text);
 		}
 	}
 

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -224,17 +224,24 @@ int main(int argc, char* argv[]) try		// // //
 
 	if (justSPCsPlease)
 	{
-		for (int i = highestGlobalSong+1; i < 256; i++)
+		// We start loading CLI songs from highestGlobalSong + 1. If no global songs are
+		// present, highestGlobalSong = 0 and we start loading songs from slot 1. We
+		// must leave slot 0 empty, because the SPC driver treats song 0 as "repeat
+		// current song" rather than a song number, making songs in slot 0 unplayable.
+		int firstLocalSong = highestGlobalSong + 1;
+
+		// Unset local songs loaded from Addmusic_list.txt.
+		for (int i = firstLocalSong; i < 256; i++)
 			musics[i].exists = false;
 
-
+		// Load local songs from command-line arguments.
 		for (int i = 0; i < textFilesToCompile.size(); i++)
 		{
-			if (highestGlobalSong + 1 + i >= 256)
+			if (firstLocalSong + i >= 256)
 				printError("Error: The total number of requested music files to compile exceeded 255.", true);
-			musics[highestGlobalSong + 1 + i].exists = true;
-			musics[highestGlobalSong + 1 + i].name = textFilesToCompile[i];
-			openTextFile((std::string("music/") + musics[i + highestGlobalSong].name), musics[i + highestGlobalSong].text);
+			musics[firstLocalSong + i].exists = true;
+			musics[firstLocalSong + i].name = textFilesToCompile[i];
+			openTextFile((std::string("music/") + musics[firstLocalSong + i].name), musics[firstLocalSong + i].text);
 		}
 	}
 


### PR DESCRIPTION
- Fix crash with too many songs on command line
- Fix C++ crash with zero global songs, while avoiding song 0
	- Remove unnecessary reading of files supplied from CLI (which used to cause the zero global song crash)

I tested that SPC export works with zero global songs. This PR should not change the behavior of ROM insertion if global songs are present, but I did not test ROM insertion at all (with or without global songs).

> We leave slot 0 empty, to match the SNES driver which treats song 0 as "repeat current song" rather than a song number, and can't send it to the SPC.

Is this comment correct? Is song 0 broken on the SPC driver, the SNES code, or both? (I can't figure out what the SPC assembly is doing to the song data index or $F6, but my local song 0 branch with zero global songs seems to generate playable SPC files.)

Fixes #262. Fixes #264. Supersedes #265.