### PR TITLE
Refactor code, fix EMPTY.brr appearing in song 1's sample directory

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -3303,7 +3303,5 @@ endif
 	SFXTable0:
 	SFXTable1:
 endif
-	SongPointers:
 
-	
-	
+SongPointers:

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1180,79 +1180,80 @@ void fixMusicPointers()
 
 	for (int i = 0; i < 256; i++)
 	{
-		if (musics[i].exists == false) continue;
+		Music & song = musics[i];
+		if (song.exists == false) continue;
 
-		musics[i].posInARAM = songDataARAMPos;
+		song.posInARAM = songDataARAMPos;
 
 		int untilJump = -1;
 
-		for (int j = 0; j < musics[i].spaceForPointersAndInstrs; j+=2)
+		for (int j = 0; j < song.spaceForPointersAndInstrs; j+=2)
 		{
 			if (untilJump == 0)
 			{
-				j += musics[i].instrumentData.size();
+				j += song.instrumentData.size();
 				untilJump = -1;
 			}
 
-			int temp = musics[i].allPointersAndInstrs[j] | musics[i].allPointersAndInstrs[j+1] << 8;
+			int temp = song.allPointersAndInstrs[j] | song.allPointersAndInstrs[j+1] << 8;
 
 			if (temp == 0xFFFF)		// 0xFFFF = swap with 0x0000.
 			{
-				musics[i].allPointersAndInstrs[j] = 0;
-				musics[i].allPointersAndInstrs[j+1] = 0;
+				song.allPointersAndInstrs[j] = 0;
+				song.allPointersAndInstrs[j+1] = 0;
 				untilJump = 1;
 			}
 			else if (temp == 0xFFFE)	// 0xFFFE = swap with 0x00FF.
 			{
-				musics[i].allPointersAndInstrs[j] = 0xFF;
-				musics[i].allPointersAndInstrs[j+1] = 0;
+				song.allPointersAndInstrs[j] = 0xFF;
+				song.allPointersAndInstrs[j+1] = 0;
 				untilJump = 2;
 			}
 			else if (temp == 0xFFFD)	// 0xFFFD = swap with the song's position (its first track pointer).
 			{
-				musics[i].allPointersAndInstrs[j] = (musics[i].posInARAM + 2) & 0xFF;
-				musics[i].allPointersAndInstrs[j+1] = (musics[i].posInARAM + 2) >> 8;
+				song.allPointersAndInstrs[j] = (song.posInARAM + 2) & 0xFF;
+				song.allPointersAndInstrs[j+1] = (song.posInARAM + 2) >> 8;
 			}
 			else if (temp == 0xFFFC)	// 0xFFFC = swap with the song's position + 2 (its second track pointer).
 			{
-				musics[i].allPointersAndInstrs[j] = musics[i].posInARAM & 0xFF;
-				musics[i].allPointersAndInstrs[j+1] = musics[i].posInARAM >> 8;
+				song.allPointersAndInstrs[j] = song.posInARAM & 0xFF;
+				song.allPointersAndInstrs[j+1] = song.posInARAM >> 8;
 			}
 			else if (temp == 0xFFFB)	// 0xFFFB = swap with 0x0000, but don't set untilSkip.
 			{
-				musics[i].allPointersAndInstrs[j] = 0;
-				musics[i].allPointersAndInstrs[j+1] = 0;
+				song.allPointersAndInstrs[j] = 0;
+				song.allPointersAndInstrs[j+1] = 0;
 			}
 			else
 			{
-				temp += musics[i].posInARAM;
-				musics[i].allPointersAndInstrs[j] = temp & 0xFF;
-				musics[i].allPointersAndInstrs[j+1] = temp >> 8;
+				temp += song.posInARAM;
+				song.allPointersAndInstrs[j] = temp & 0xFF;
+				song.allPointersAndInstrs[j+1] = temp >> 8;
 			}
 			untilJump--;
 		}
 
-		int normalChannelsSize = musics[i].data[0].size() + musics[i].data[1].size() + musics[i].data[2].size() + musics[i].data[3].size() + musics[i].data[4].size() + musics[i].data[5].size() + musics[i].data[6].size() + musics[i].data[7].size();
+		int normalChannelsSize = song.data[0].size() + song.data[1].size() + song.data[2].size() + song.data[3].size() + song.data[4].size() + song.data[5].size() + song.data[6].size() + song.data[7].size();
 
 		for (int j = 0; j < 9; j++)
 		{
-			for (unsigned int k = 0; k < musics[i].loopLocations[j].size(); k++)
+			for (unsigned int k = 0; k < song.loopLocations[j].size(); k++)
 			{
-				int temp = (musics[i].data[j][musics[i].loopLocations[j][k]] & 0xFF) | (musics[i].data[j][musics[i].loopLocations[j][k] + 1] << 8);
-				temp += musics[i].posInARAM + normalChannelsSize + musics[i].spaceForPointersAndInstrs;
-				musics[i].data[j][musics[i].loopLocations[j][k]] = temp & 0xFF;
-				musics[i].data[j][musics[i].loopLocations[j][k] + 1] = temp >> 8;
+				int temp = (song.data[j][song.loopLocations[j][k]] & 0xFF) | (song.data[j][song.loopLocations[j][k] + 1] << 8);
+				temp += song.posInARAM + normalChannelsSize + song.spaceForPointersAndInstrs;
+				song.data[j][song.loopLocations[j][k]] = temp & 0xFF;
+				song.data[j][song.loopLocations[j][k] + 1] = temp >> 8;
 			}
 		}
 
 
 		std::vector<uint8_t> final;
 
-		int sizeWithPadding = (musics[i].minSize > 0) ? musics[i].minSize : musics[i].totalSize;
+		int sizeWithPadding = (song.minSize > 0) ? song.minSize : song.totalSize;
 
 		if (i > highestGlobalSong)
 		{
-			int RATSSize = musics[i].totalSize + 4 - 1;
+			int RATSSize = song.totalSize + 4 - 1;
 			final.push_back('S');
 			final.push_back('T');
 			final.push_back('A');
@@ -1272,22 +1273,22 @@ void fixMusicPointers()
 		}
 
 
-		for (unsigned int j = 0; j < musics[i].allPointersAndInstrs.size(); j++)
-			final.push_back(musics[i].allPointersAndInstrs[j]);
+		for (unsigned int j = 0; j < song.allPointersAndInstrs.size(); j++)
+			final.push_back(song.allPointersAndInstrs[j]);
 
 		for (unsigned int j = 0; j < 9; j++)
-			for (unsigned int k = 0; k < musics[i].data[j].size(); k++)
-				final.push_back(musics[i].data[j][k]);
+			for (unsigned int k = 0; k < song.data[j].size(); k++)
+				final.push_back(song.data[j][k]);
 
-		if (musics[i].minSize > 0 && i <= highestGlobalSong)
-			while (final.size() < musics[i].minSize)
+		if (song.minSize > 0 && i <= highestGlobalSong)
+			while (final.size() < song.minSize)
 				final.push_back(0);
 
 
 		if (i > highestGlobalSong)
 		{
-			musics[i].finalData.resize(final.size() - 12);
-			musics[i].finalData.assign(final.begin() + 12, final.end());
+			song.finalData.resize(final.size() - 12);
+			song.finalData.assign(final.begin() + 12, final.end());
 		}
 
 		std::stringstream fname;
@@ -1304,58 +1305,58 @@ void fixMusicPointers()
 		{
 			if (checkEcho)
 			{
-				musics[i].spaceInfo.songStartPos = songDataARAMPos;
-				musics[i].spaceInfo.songEndPos = musics[i].spaceInfo.songStartPos + sizeWithPadding;
+				song.spaceInfo.songStartPos = songDataARAMPos;
+				song.spaceInfo.songEndPos = song.spaceInfo.songStartPos + sizeWithPadding;
 
 				int checkPos = songDataARAMPos + sizeWithPadding;
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
-				musics[i].spaceInfo.sampleTableStartPos = checkPos;
+				song.spaceInfo.sampleTableStartPos = checkPos;
 
-				checkPos += musics[i].mySamples.size() * 4;
+				checkPos += song.mySamples.size() * 4;
 
-				musics[i].spaceInfo.sampleTableEndPos = checkPos;
+				song.spaceInfo.sampleTableEndPos = checkPos;
 
 				int importantSampleCount = 0;
-				for (unsigned int j = 0; j < musics[i].mySamples.size(); j++)
+				for (unsigned int j = 0; j < song.mySamples.size(); j++)
 				{
-					auto thisSample = musics[i].mySamples[j];
+					auto thisSample = song.mySamples[j];
 					auto thisSampleSize = samples[thisSample].data.size();
 					bool sampleIsImportant = samples[thisSample].important;
 					if (sampleIsImportant) importantSampleCount++;
 
-					musics[i].spaceInfo.individualSampleStartPositions.push_back(checkPos);
-					musics[i].spaceInfo.individualSampleEndPositions.push_back(checkPos + thisSampleSize);
-					musics[i].spaceInfo.individialSampleIsImportant.push_back(sampleIsImportant);
+					song.spaceInfo.individualSampleStartPositions.push_back(checkPos);
+					song.spaceInfo.individualSampleEndPositions.push_back(checkPos + thisSampleSize);
+					song.spaceInfo.individialSampleIsImportant.push_back(sampleIsImportant);
 
 					checkPos += thisSampleSize;
 				}
-				musics[i].spaceInfo.importantSampleCount = importantSampleCount;
+				song.spaceInfo.importantSampleCount = importantSampleCount;
 
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
-				//musics[i].spaceInfo.echoBufferStartPos = checkPos;
+				//song.spaceInfo.echoBufferStartPos = checkPos;
 
-				checkPos += musics[i].echoBufferSize << 11;
+				checkPos += song.echoBufferSize << 11;
 
-				//musics[i].spaceInfo.echoBufferEndPos = checkPos;
+				//song.spaceInfo.echoBufferEndPos = checkPos;
 
-				musics[i].spaceInfo.echoBufferEndPos = 0x10000;
-				if (musics[i].echoBufferSize > 0)
+				song.spaceInfo.echoBufferEndPos = 0x10000;
+				if (song.echoBufferSize > 0)
 				{
-					musics[i].spaceInfo.echoBufferStartPos = 0x10000 - (musics[i].echoBufferSize << 11);
-					musics[i].spaceInfo.echoBufferEndPos = 0x10000;
+					song.spaceInfo.echoBufferStartPos = 0x10000 - (song.echoBufferSize << 11);
+					song.spaceInfo.echoBufferEndPos = 0x10000;
 				}
 				else
 				{
-					musics[i].spaceInfo.echoBufferStartPos = 0xFF00;
-					musics[i].spaceInfo.echoBufferEndPos = 0xFF04;
+					song.spaceInfo.echoBufferStartPos = 0xFF00;
+					song.spaceInfo.echoBufferEndPos = 0xFF04;
 				}
 
 
 				if (checkPos > 0x10000)
 				{
-					std::cerr << musics[i].name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << checkPos - 0x10000 << " bytes." << std::dec << std::endl;
+					std::cerr << song.name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << checkPos - 0x10000 << " bytes." << std::dec << std::endl;
 					quit(1);
 				}
 			}

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -541,7 +541,7 @@ void loadMusicList()
 				highestGlobalSong = std::max(highestGlobalSong, index);
 			if (inLocals)
 				if (index <= highestGlobalSong)
-					printError("Error: Local song numbers must be lower than the largest global song number.", true);
+					printError("Error: Local song numbers must be greater than the largest global song number.", true);
 		}
 		else
 		{

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1143,15 +1143,40 @@ void fixMusicPointers()
 	if (verbose)
 		std::cout << "Fixing song pointers..." << std::endl;
 
-	int pointersPos = programSize + 0x400;
-	std::stringstream globalPointers;
-	std::stringstream incbins;
+	// Text appended to main.asm after the SongPointers: label.
+	std::stringstream songDataSrc;
 
+	// Generate songDataSrc.
+	{
+		// Populate SongPointers table with addresses of songs present.
+		for (int i = 0; i < 256; i++)
+		{
+			if (musics[i].exists == false) continue;
+			if (i <= highestGlobalSong)
+				songDataSrc << "\tdw song" << hex2 << i << "\n";
+			else
+				break;
+		}
+		songDataSrc << "\tdw localSong\n\n";
+
+		// Populate destinations of SongPointers table with song data.
+		for (int i = 0; i < 256; i++)
+		{
+			if (musics[i].exists == false) continue;
+			if (i <= highestGlobalSong)
+				songDataSrc << "song" << hex2 << i << ": incbin \"SNES/bin/music" << hex2 << i << ".bin\"\n";
+			else
+				break;
+		}
+		// The localSong label is at the very end of asm/tempmain.asm (compiled to
+		// asm/SNES/bin/main.bin). It points to a local song loaded in ARAM just after
+		// asm/SNES/bin/main.bin.
+		songDataSrc << "localSong:\n";
+	}
+
+	// Process songs.
 	int songDataARAMPos = programSize + programPos + highestGlobalSong * 2 + 2;
 	//                    size + startPos + pointer to each global song + pointer to local song.
-	//int songPointerARAMPos = programSize + programPos;
-
-	bool addedLocalPtr = false;
 
 	for (int i = 0; i < 256; i++)
 	{
@@ -1160,18 +1185,6 @@ void fixMusicPointers()
 		musics[i].posInARAM = songDataARAMPos;
 
 		int untilJump = -1;
-
-		if (i <= highestGlobalSong)
-		{
-			globalPointers << "\ndw song" << hex2 << i;
-			incbins << "song" << hex2 << i << ": incbin \"" << "SNES/bin/" << "music" << hex2 << i << ".bin\"\n";
-		}
-		else if (addedLocalPtr == false)
-		{
-			globalPointers << "\ndw localSong";
-			incbins << "localSong: ";
-			addedLocalPtr = true;
-		}
 
 		for (int j = 0; j < musics[i].spaceForPointersAndInstrs; j+=2)
 		{
@@ -1354,7 +1367,7 @@ void fixMusicPointers()
 	std::string patch;
 	openTextFile("asm/tempmain.asm", patch);
 
-	patch += globalPointers.str() + "\n" + incbins.str();
+	patch += songDataSrc.str();
 
 	writeTextFile("asm/tempmain.asm", patch);
 

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2901,13 +2901,13 @@ void Music::pointersFirstPass()
 		//This specifically involves phrase pointers, loop locations and remote gain positions.
 		//Why isn't this done sooner? Because we don't know whether some of these are even going to be in there in the first place.
 		for (int a = 0; a < loopLocations[resizedChannel].size(); a++) {
-			loopLocations[resizedChannel][a] = loopLocations[resizedChannel][a]+z;
+			loopLocations[resizedChannel][a] += z;
 		}
 		for (int a = 0; a < remoteGainPositions[resizedChannel].size(); a++) {
-			remoteGainPositions[resizedChannel][a] = remoteGainPositions[resizedChannel][a]+z;
+			remoteGainPositions[resizedChannel][a] += z;
 		}
 		for (int a = 0; a <= 1; a++) {
-			phrasePointers[resizedChannel][a] = phrasePointers[resizedChannel][a]+z;
+			phrasePointers[resizedChannel][a] += z;
 		}
 	}
 

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2934,7 +2934,8 @@ void Music::pointersFirstPass()
 		int emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		if (emptySampleIndex == -1)
 		{
-			addSample("EMPTY.brr", this, true);
+			// Add EMPTY.brr to global::samples and global::sampleToIndex, but not mySamples.
+			addSample("EMPTY.brr", nullptr, true);
 			emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		}
 

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -783,10 +783,13 @@ void Music::parseInstrumentCommand()
 		{
 			if (i < 30)
 				usedSamples[instrToSample[i]] = true;
-			else if ((i - 30) * 6 < instrumentData.size())
-				usedSamples[instrumentData[(i - 30) * 6]] = true;
-			else
-				error("This custom instrument has not been defined yet.")
+			else {
+				int customInstrIndex = i - 30;
+				if (customInstrIndex * 6 < instrumentData.size())
+					usedSamples[instrumentData[customInstrIndex * 6]] = true;
+				else
+					error("This custom instrument has not been defined yet.")
+			}
 		}
 
 		if (songTargetProgram == 1)

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -850,19 +850,10 @@ void Music::parseSampleLoadCommand()
 			error("Error parsing sample load command.")
 				return;
 		}
-		i = -1;
 
 		s = basepath + s;
 
-		int gs = getSample(s, this);
-		for (j = 0; j < mySamples.size(); j++)
-		{
-			if (mySamples[j] == gs)
-			{
-				i = j;
-				break;
-			}
-		}
+		i = getMySample(s, this);
 
 		if (i == -1)
 			error("The specified sample was not included in this song.");
@@ -2506,18 +2497,8 @@ void Music::parseInstrumentDefinitions()
 				brrName += text[pos++];
 			}
 			pos++;
-			i = -1;
 			brrName = basepath + brrName;
-			int gs = getSample(brrName, this);
-			for (j = 0; j < mySamples.size(); j++)
-			{
-				if (mySamples[j] == gs)
-				{
-					i = j;
-					break;
-				}
-			}
-
+			i = getMySample(brrName, this);
 
 			if (i == -1)
 				fatalError("The specified sample was not included in this song.")
@@ -2950,11 +2931,11 @@ void Music::pointersFirstPass()
 
 	if (optimizeSampleUsage)
 	{
-		int emptySampleIndex = ::getSample("EMPTY.brr", this);
+		int emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		if (emptySampleIndex == -1)
 		{
 			addSample("EMPTY.brr", this, true);
-			emptySampleIndex = getSample("EMPTY.brr", this);
+			emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		}
 
 

--- a/src/AddmusicK/Music.h
+++ b/src/AddmusicK/Music.h
@@ -64,7 +64,7 @@ public:
 
 	int index;
 
-	//uint8_t mySamples[255];
+	/// vector[MySampleIndex] GlobalSampleIndex
 	std::vector<unsigned short> mySamples;
 	//int mySampleCount;
 	int echoBufferSize;

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <iomanip>
 #include <cstdlib>
+#include <cstdint>
 #include <cstring>
 #include <map>
 #include <stack>
@@ -17,7 +18,6 @@
 std::vector<uint8_t> rom;
 
 Music musics[256];
-//Sample samples[256];
 std::vector<Sample> samples;
 SoundEffect soundEffectsDF9[256];
 SoundEffect soundEffectsDFC[256];
@@ -615,7 +615,7 @@ void addSampleBank(const File &fileName, Music *music)
 	}
 }
 
-int getSample(const File &name, Music *music)
+int getGlobalSample(const File &name, Music *music)
 {
 	std::string actualPath = "";
 
@@ -652,6 +652,23 @@ int getSample(const File &name, Music *music)
 	}
 
 
+	return -1;
+}
+
+// Returns an index into Music::mySamples, or -1 if not found.
+int getMySample(const File &name, Music *music)
+{
+	int gs = getGlobalSample(name, music);
+	if (gs == -1)
+		return -1;
+
+	for (size_t j = 0; j < music->mySamples.size(); j++)
+	{
+		if (music->mySamples[j] == gs)
+		{
+			return (int) j;
+		}
+	}
 	return -1;
 }
 

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -151,8 +151,8 @@ int PCToSNES(int addr);
 int clearRATS(int PCaddr);
 bool findRATS(int addr);
 
-void addSample(const File &fileName, Music *music, bool important);
-void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint = 0, bool isBNK = false);
+void addSample(const File &fileName, Music *maybeMusic, bool important);
+void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *maybeMusic, bool important, bool noLoopHeader, int loopPoint = 0, bool isBNK = false);
 void addSampleGroup(const File &fileName, Music *music);
 void addSampleBank(const File &fileName, Music *music);
 

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -57,11 +57,13 @@ class SampleGroup;
 extern std::vector<uint8_t> rom;
 
 extern Music musics[256];
-//extern Sample samples[256];
+
+/// vector[GlobalSampleIndex] Sample
 extern std::vector<Sample> samples;
 extern SoundEffect *soundEffects[2];	// soundEffects[2][256];
 extern std::vector<BankDefine *> bankDefines;
 
+/// map[str] GlobalSampleIdx
 extern std::map<File, int> sampleToIndex;
 
 extern bool convert;
@@ -154,7 +156,8 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 void addSampleGroup(const File &fileName, Music *music);
 void addSampleBank(const File &fileName, Music *music);
 
-int getSample(const File &name, Music *music);
+int getGlobalSample(const File &name, Music *music);
+int getMySample(const File &name, Music *music);
 
 void preprocess(std::string &str, const std::string &filename, int &version);
 


### PR DESCRIPTION
A pile of bugfixes and refactors. I recommend reading each commit individually.

- "When adding EMPTY.brr, don't add to Music::mySamples" depends on "Split getSample() into getGlobalSample() and getMySample()".
- "In fixMusicPointers(), clarify loopLocations handling" depends on "In fixMusicPointers(), extract repeated global_musics[i] into song".

I verified that this branch compiles, SPC building works, and `12 Water.spc` is bit-identical between master and this branch (only tested with global songs present). I haven't done as much testing as my `fork` branch (both were only tested in -norom), but the diff between this and `fork` is small (mostly debug statements).

Not sure if you'll merge all commits or not.