### PR TITLE
Fix EMPTY.brr appearing in song 1's sample directory

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2934,7 +2934,8 @@ void Music::pointersFirstPass()
 		int emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		if (emptySampleIndex == -1)
 		{
-			addSample("EMPTY.brr", this, true);
+			// Add EMPTY.brr to global::samples and global::sampleToIndex, but not mySamples.
+			addSample("EMPTY.brr", nullptr, true);
 			emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		}
 

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -850,19 +850,10 @@ void Music::parseSampleLoadCommand()
 			error("Error parsing sample load command.")
 				return;
 		}
-		i = -1;
 
 		s = basepath + s;
 
-		int gs = getSample(s, this);
-		for (j = 0; j < mySamples.size(); j++)
-		{
-			if (mySamples[j] == gs)
-			{
-				i = j;
-				break;
-			}
-		}
+		i = getMySample(s, this);
 
 		if (i == -1)
 			error("The specified sample was not included in this song.");
@@ -2506,18 +2497,8 @@ void Music::parseInstrumentDefinitions()
 				brrName += text[pos++];
 			}
 			pos++;
-			i = -1;
 			brrName = basepath + brrName;
-			int gs = getSample(brrName, this);
-			for (j = 0; j < mySamples.size(); j++)
-			{
-				if (mySamples[j] == gs)
-				{
-					i = j;
-					break;
-				}
-			}
-
+			i = getMySample(brrName, this);
 
 			if (i == -1)
 				fatalError("The specified sample was not included in this song.")
@@ -2950,11 +2931,11 @@ void Music::pointersFirstPass()
 
 	if (optimizeSampleUsage)
 	{
-		int emptySampleIndex = ::getSample("EMPTY.brr", this);
+		int emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		if (emptySampleIndex == -1)
 		{
 			addSample("EMPTY.brr", this, true);
-			emptySampleIndex = getSample("EMPTY.brr", this);
+			emptySampleIndex = getGlobalSample("EMPTY.brr", this);
 		}
 
 

--- a/src/AddmusicK/Music.h
+++ b/src/AddmusicK/Music.h
@@ -64,7 +64,7 @@ public:
 
 	int index;
 
-	//uint8_t mySamples[255];
+	/// vector[MySampleIndex] GlobalSampleIndex
 	std::vector<unsigned short> mySamples;
 	//int mySampleCount;
 	int echoBufferSize;

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -17,7 +17,6 @@
 std::vector<uint8_t> rom;
 
 Music musics[256];
-//Sample samples[256];
 std::vector<Sample> samples;
 SoundEffect soundEffectsDF9[256];
 SoundEffect soundEffectsDFC[256];
@@ -615,7 +614,7 @@ void addSampleBank(const File &fileName, Music *music)
 	}
 }
 
-int getSample(const File &name, Music *music)
+int getGlobalSample(const File &name, Music *music)
 {
 	std::string actualPath = "";
 
@@ -652,6 +651,23 @@ int getSample(const File &name, Music *music)
 	}
 
 
+	return -1;
+}
+
+// Returns an index into Music::mySamples, or -1 if not found.
+int getMySample(const File &name, Music *music)
+{
+	int gs = getGlobalSample(name, music);
+	if (gs == -1)
+		return -1;
+
+	for (size_t j = 0; j < music->mySamples.size(); j++)
+	{
+		if (music->mySamples[j] == gs)
+		{
+			return (int) j;
+		}
+	}
 	return -1;
 }
 

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -420,30 +420,39 @@ int clearRATS(int offset)
 	return r+1;
 }
 
-void addSample(const File &fileName, Music *music, bool important)
+void addSample(const File &fileName, Music *maybeMusic, bool important)
 {
 	std::vector<uint8_t> temp;
 	std::string actualPath = "";
 
-	std::string relativeDir = music->name;
-	std::string absoluteDir = "samples/" + (std::string)fileName;
-	std::replace(relativeDir.begin(), relativeDir.end(), '\\', '/');
-	relativeDir = "music/" + relativeDir;
-	relativeDir = relativeDir.substr(0, relativeDir.find_last_of('/'));
-	relativeDir += "/" + (std::string)fileName;
+	if (maybeMusic)
+	{
+		std::string relativeDir = maybeMusic->name;
+		std::replace(relativeDir.begin(), relativeDir.end(), '\\', '/');
+		relativeDir = "music/" + relativeDir;
+		relativeDir = relativeDir.substr(0, relativeDir.find_last_of('/'));
+		relativeDir += "/" + (std::string)fileName;
+		if (fileExists(relativeDir))
+		{
+			actualPath = relativeDir;
+		}
+	}
 
-	if (fileExists(relativeDir))
-		actualPath = relativeDir;
-	else if (fileExists(absoluteDir))
-		actualPath = absoluteDir;
-	else
-		printError("Could not find sample " + (std::string)fileName, true, music->name);
+	if (actualPath.empty())
+	{
+		std::string absoluteDir = "samples/" + (std::string)fileName;
+		if (fileExists(absoluteDir))
+				actualPath = absoluteDir;
+	}
+
+	if (actualPath.empty())
+		printError("Could not find sample " + (std::string)fileName, true, maybeMusic ? maybeMusic->name : "");
 
 	openFile(actualPath, temp);
-	addSample(temp, actualPath, music, important, false);
+	addSample(temp, actualPath, maybeMusic, important, false);
 }
 
-void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint, bool isBNK)
+void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *maybeMusic, bool important, bool noLoopHeader, int loopPoint, bool isBNK)
 {
 	Sample newSample;
 	newSample.important = important;
@@ -479,7 +488,8 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 		{
 			if (samples[i].name == newSample.name)
 			{
-				music->mySamples.push_back(i);
+				if (maybeMusic)
+					maybeMusic->mySamples.push_back(i);
 				return;						// Don't add two of the same sample.
 			}
 		}
@@ -492,7 +502,8 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 				if (!(newSample.isBNK)) {
 					sampleToIndex[name] = i;
 				}
-				music->mySamples.push_back(i);
+				if (maybeMusic)
+					maybeMusic->mySamples.push_back(i);
 				return;
 			}
 		}
@@ -519,7 +530,8 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 	if (!(newSample.isBNK)) {
 		sampleToIndex[newSample.name] = samples.size();
 	}
-	music->mySamples.push_back(samples.size());
+	if (maybeMusic)
+		maybeMusic->mySamples.push_back(samples.size());
 	samples.push_back(newSample);					// This is a sample we haven't encountered before.  Add it.
 }
 

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -151,8 +151,8 @@ int PCToSNES(int addr);
 int clearRATS(int PCaddr);
 bool findRATS(int addr);
 
-void addSample(const File &fileName, Music *music, bool important);
-void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *music, bool important, bool noLoopHeader, int loopPoint = 0, bool isBNK = false);
+void addSample(const File &fileName, Music *maybeMusic, bool important);
+void addSample(const std::vector<uint8_t> &sample, const std::string &name, Music *maybeMusic, bool important, bool noLoopHeader, int loopPoint = 0, bool isBNK = false);
 void addSampleGroup(const File &fileName, Music *music);
 void addSampleBank(const File &fileName, Music *music);
 

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -57,11 +57,13 @@ class SampleGroup;
 extern std::vector<uint8_t> rom;
 
 extern Music musics[256];
-//extern Sample samples[256];
+
+/// vector[GlobalSampleIndex] Sample
 extern std::vector<Sample> samples;
 extern SoundEffect *soundEffects[2];	// soundEffects[2][256];
 extern std::vector<BankDefine *> bankDefines;
 
+/// map[str] GlobalSampleIdx
 extern std::map<File, int> sampleToIndex;
 
 extern bool convert;
@@ -154,7 +156,8 @@ void addSample(const std::vector<uint8_t> &sample, const std::string &name, Musi
 void addSampleGroup(const File &fileName, Music *music);
 void addSampleBank(const File &fileName, Music *music);
 
-int getSample(const File &name, Music *music);
+int getGlobalSample(const File &name, Music *music);
+int getMySample(const File &name, Music *music);
 
 void preprocess(std::string &str, const std::string &filename, int &version);
 


### PR DESCRIPTION
This fixes a bug where when running in -norom mode with all global songs removed, the first generated SPC file has an extra unused EMPTY.brr sample slot.

Extracted from #272. I removed adding `<cstdint>` to `globals.cpp`, since it's neither necessary nor sufficient to ensure size_t is present (`<cstdlib>` and `<cstddef>` both come with size_t, though `cstdlib` lacks `ptrdiff_t` and friends) and `globals.cpp` already includes `<cstdlib>`.