### PR TITLE
Add the option to restart P-Switch and Star global songs on retrigger

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -682,7 +682,8 @@ endif
 
 else
 	LDA $1490|!SA1Addr2		; If both P-switch and starman music should be playing
-	BNE .starMusic			;;; just play the star music
+	CMP #$1E
+	BCS .starMusic			;;; just play the star music
 endif
 
 if !PSwitchIsSFX = !false && !PSwitchStarRestart == !false

--- a/asm/UserDefines.asm
+++ b/asm/UserDefines.asm
@@ -218,7 +218,7 @@ includeonce
 
 ;=======================================
 ;---------------
-!PSwitchStarRestart = !true
+!PSwitchStarRestart = !false
 
 ;Default setting: !false
 ;Vanilla setting: !true

--- a/asm/UserDefines.asm
+++ b/asm/UserDefines.asm
@@ -217,6 +217,18 @@ includeonce
 ;=======================================
 
 ;=======================================
+;---------------
+!PSwitchStarRestart = !true
+
+;Default setting: !false
+;Vanilla setting: !true
+;---------------
+; If you set this to true, then the P-switch and star global songs will 
+; restart whenever they're called again (i.e., by pressing another P-switch
+; or collecting another star).
+;=======================================
+
+;=======================================
 ; If you've changed list.txt and plan on using the original SMW songs
 ; change these constants to whatever they are in list.txt
 ; For example, if you changed the "Stage Clear" music to be number 9,


### PR DESCRIPTION
This code was initially contributed by the JUMP team, with SimFan96 updating it
for AddmusicK 1.0.6. KevinM then made a version for 1.0.8, which Anas then
modified to be user definable as well as some adaptation for the modifications
that were made in the AMKFF fork, and I made some final adjustments. This
replicates vanilla SMW behavior where these songs restart when they are
retriggered.

This merge request closes #193.