### PR TITLE
Have passedNote refer to a previous channel if it is in a loop

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2109,7 +2109,12 @@ void Music::markEchoBufferAllocVCMD()
 
 void Music::parseNote()
 {
-	passedNote[channel] = true;
+	if (channel != 8) {
+		passedNote[channel] = true;
+	}
+	else {
+		passedNote[prevChannel] = true;
+	}
 	j = tolower(text[pos]);
 	pos++;
 


### PR DESCRIPTION
passedNote and passedIntro do not have loops counted as part of their counts,
and this particular case meant that an out of bounds write was accidentally
enabled.

This pull request closes #291.