### PR TITLE
Fix memory leak with BankDefine instances

### DIFF
--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -634,9 +634,9 @@ void loadSampleList()
 		{
 			if (isspace(str[i]))
 			{
-				BankDefine *sg = new BankDefine;
+				std::unique_ptr<BankDefine> sg = std::make_unique<BankDefine>();
 				sg->name = groupName;
-				bankDefines.push_back(sg);
+				bankDefines.push_back(std::move(sg));
 				i++;
 				gettingGroupName = false;
 				continue;
@@ -655,7 +655,7 @@ void loadSampleList()
 				if (str[i] == '\"')
 				{
 					tempName.erase(tempName.begin(), tempName.begin() + 1);
-					bankDefines[bankDefines.size() - 1]->samples.push_back(new std::string(tempName));
+					bankDefines[bankDefines.size() - 1]->samples.push_back(std::make_unique<std::string>(tempName));
 					bankDefines[bankDefines.size() - 1]->importants.push_back(false);
 					tempName.clear();
 					i++;

--- a/src/AddmusicK/BankDefine.h
+++ b/src/AddmusicK/BankDefine.h
@@ -1,11 +1,13 @@
 #ifndef _BANKDEFINE_H
 #define _BANKDEFINE_H
 
+#include <memory>
+
 class BankDefine
 {
 public:
 	std::string name;
-	std::vector<const std::string *> samples;
+	std::vector<std::unique_ptr<const std::string>> samples;
 	std::vector<bool> importants;
 };
 

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -23,7 +23,7 @@ SoundEffect soundEffectsDF9[256];
 SoundEffect soundEffectsDFC[256];
 SoundEffect *soundEffects[2] = {soundEffectsDF9, soundEffectsDFC};
 //std::vector<SampleGroup> sampleGroups;
-std::vector<BankDefine *> bankDefines;
+std::vector<std::unique_ptr<BankDefine>> bankDefines;
 std::map<File, int> sampleToIndex;
 
 bool convert = true;

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -47,6 +47,7 @@ class SampleGroup;
 #include <vector>
 #include <fstream>
 #include <map>
+#include <memory>
 #include "Directory.h"
 #include "asardll.h"
 #include <sys/types.h>
@@ -60,7 +61,7 @@ extern Music musics[256];
 //extern Sample samples[256];
 extern std::vector<Sample> samples;
 extern SoundEffect *soundEffects[2];	// soundEffects[2][256];
-extern std::vector<BankDefine *> bankDefines;
+extern std::vector<std::unique_ptr<BankDefine>> bankDefines;
 
 extern std::map<File, int> sampleToIndex;
 


### PR DESCRIPTION
Contributed by Atari 2.0. <memory> is brought into the picture for the methods
that are used to ensure that the BankDefines do not overwrite other memory
locations by utilizing unique pointers and marking them as movable as needed
when utilizing them with the pre-existing vectors.

This merge request closes #290.