### PR TITLE
In arpeggio, don't set up notes past !WaitTime if a new base note is incoming

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -1153,7 +1153,14 @@ cmdFB_fetchLength:
 HandleArpeggio:				; Routine that controls all things arpeggio-related.
 	mov	a, !ArpNoteCount+x	; \ If the note count is 0, then this channel is not using arpeggio.
 	beq	.return			; /
-	
+.nextNoteCheck
+	beq	.skipWaitTimeCheck
+	mov	a, !WaitTime		; \
+	cmp	a, !ArpLength+x		; | Don't prepare another note when the next base note is to be keyed on.
+	bcs	.skipWaitTimeCheck	; | An exception is made if the requested length is less than or equal
+	cmp	a, $70+x		; | to !WaitTime, since they bypass keying off anyways that way.
+	bcs	.return			; /
+.skipWaitTimeCheck
 	mov	a, !ArpTimeLeft+x	; \
 	dec	a			; | Decrement the timer.
 	mov	!ArpTimeLeft+x, a	; /

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -3015,6 +3015,7 @@ L_10A1:
 	bne	.noRemoteCode				; /
 	
 	call	ShouldSkipKeyOff			; \ If we're going to skip the keyoff, then also don't run the code.
+	mov1	HandleArpeggio_nextNoteCheck.5, c	; | Switch between a BEQ/BNE opcode depending on the output.
 	bcc	.noRemoteCode				; /
 	
 	call	RunRemoteCode				;
@@ -3024,7 +3025,7 @@ L_10A1:
 	cbne	$70+x, +				;
 .doKeyOffCheck
 	call	ShouldSkipKeyOff
-	
+	mov1	HandleArpeggio_nextNoteCheck.5, c	; Switch between a BEQ/BNE opcode depending on the output.
 	bcc	+
 	call	KeyOffVoiceWithCheck 
 +


### PR DESCRIPTION
With the exception of notes being keyed on faster than !WaitTime ticks, no
processing should be done when a new base note is to be set up.

This merge request closes #294.