### PR TITLE
Revive UseGainInstead for remote code as remote gain-like function

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -337,18 +337,16 @@ RunRemoteCode2:
 }
 
 UseGainInstead:
-	push	a			; 
+	mov	y, a			;
 	mov	a, x			; \
-	lsr	a			; | GAIN Register into y
+	lsr	a			; | GAIN Register into a
 	xcn	a			; |
-	or	a, #$07			; |
-	mov	y, a			; /
-	pop	a			; 
-	call	DSPWrite		; Write
-	dec	y			; \
-	dec	y			; | Clear ADSR bit to force GAIN.
-	mov	a, #$7f			; |
-	call	DSPWrite		; /
+	or	a, #$07			; /
+	movw	$f2, ya			; Write
+	dec	a			; \
+	dec	a			; | Clear ADSR bit to force GAIN.
+	mov	y, #$7f			; |
+	movw	$f2, ya			; /
 	bra	RestoreTrackPtrFromStack
 	
 ; handle a note vcmd

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -306,9 +306,10 @@ RunRemoteCode:
 	mov	a, $31+x
 	push	a
 	mov	a, !remoteCodeTargetAddr+x
-	mov	$30+x, a
+	mov	y, a
 	mov	a, !remoteCodeTargetAddr+1+x
 RunRemoteCode_Exec:
+	mov	$30+x, y
 	mov	$31+x, a
 	dec	a
 	beq	UseGainInstead
@@ -331,13 +332,12 @@ RunRemoteCode2:
 	mov	a, $31+x
 	push	a
 	mov	a, !remoteCodeTargetAddr2+x
-	mov	$30+x, a
+	mov	y, a
 	mov	a, !remoteCodeTargetAddr2+1+x
 	bra	RunRemoteCode_Exec
 }
 
 UseGainInstead:
-	mov	y, a			;
 	mov	a, x			; \
 	lsr	a			; | GAIN Register into a
 	xcn	a			; |

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -310,6 +310,8 @@ RunRemoteCode:
 	mov	a, !remoteCodeTargetAddr+1+x
 RunRemoteCode_Exec:
 	mov	$31+x, a
+	dec	a
+	beq	UseGainInstead
 	mov	a, #$6f			;RET opcode
 	mov	runningRemoteCodeGate, a
 	call	L_0C57			; This feels evil.  Oh well.  At any rate, this'll run the code we give it.
@@ -333,6 +335,21 @@ RunRemoteCode2:
 	mov	a, !remoteCodeTargetAddr2+1+x
 	bra	RunRemoteCode_Exec
 }
+
+UseGainInstead:
+	push	a			; 
+	mov	a, x			; \
+	lsr	a			; | GAIN Register into y
+	xcn	a			; |
+	or	a, #$07			; |
+	mov	y, a			; /
+	pop	a			; 
+	call	DSPWrite		; Write
+	dec	y			; \
+	dec	y			; | Clear ADSR bit to force GAIN.
+	mov	a, #$7f			; |
+	call	DSPWrite		; /
+	bra	RestoreTrackPtrFromStack
 	
 ; handle a note vcmd
 NoteVCMD:			
@@ -359,19 +376,6 @@ endif
 	tclr	$0162, a
 L_05CD:
 	ret
-;UseGainInstead:
-;	push	a			; 
-;	mov	a, x			; \
-;	lsr	a			; | GAIN Register into y
-;	xcn	a			; |
-;	or	a, #$07			; |
-;	mov	y, a			; /
-;	pop	a			; 
-;	call	DSPWrite		; Write
-;	dec	y			; \
-;	dec	y			; | Clear ADSR bit to force GAIN.
-;	mov	a, #$7f			; |
-;	jmp	DSPWrite		; /
 	
 PercNote:
 	

--- a/readme_files/hex_command_reference.html
+++ b/readme_files/hex_command_reference.html
@@ -844,7 +844,7 @@
 		<td rowspan="4">$FC</td>
 		<td rowspan="4">AddmusicK<br></td>
 		<td rowspan="4">Remote commands</td>
-		<td rowspan="4">See the corresponding entry in the syntax reference section for more information.<br><br>For the sake of reference, for songs labeled #amk 1, this command is anticipation gain.  It used to cause gain to occur some amount of time before a note ended. It has been replaced entirely with remote commands, and will be converted to that in current versions of AddmusicK.</td>
+		<td rowspan="4">See the corresponding entry in the syntax reference section for more information.</td>
 		<td>$WW<br></td>
 		<td>Address to jump to, low byte (not used for event type 0)<br></td>
 	</tr>
@@ -858,6 +858,26 @@
 	</tr>
 	<tr>
 		<td>$ZZ</td>
+		<td><a href="#LengthInfo">How long to wait when using wait types 1 or 2.</a> Note that a value of $00 is treated as $0100<br></td>
+	</tr><tr><td colspan="6">&nbsp;</td></tr>
+	<tr>
+		<td rowspan="4">$FC</td>
+		<td rowspan="4">New<br></td>
+		<td rowspan="4">Remote Gain</td>
+		<td rowspan="4">See the corresponding entry in the syntax reference section for more information.<br><br>For the sake of reference, for songs labeled #amk 1, this command is essentially a more customizable version of remote gain and anticipation gain (though in both cases you need a -1 event type to automate instrument restoration unless you want to do something else), with remote gain previously using type 2 and anticipation gain using type 3.</td>
+		<td>$WW<br></td>
+		<td>GAIN value to set on trigger.</td>
+	</tr>
+	<tr>
+		<td>$01<br></td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>$XX<br></td>
+		<td>The event type<br></td>
+	</tr>
+	<tr>
+		<td>$YY</td>
 		<td><a href="#LengthInfo">How long to wait when using wait types 1 or 2.</a> Note that a value of $00 is treated as $0100<br></td>
 	</tr><tr><td colspan="6">&nbsp;</td></tr>
 	<tr>
@@ -1137,7 +1157,8 @@ The highest command ID supported was $FC.
 	</tr>
 	<tr>
 		<td rowspan="2">$FA <br></td>
-		<td rowspan="2">N/A<br>(In general, this can be replicated for the most part using two remote code calls: a type 3 remote code call with the $F6 command (however, voice-specific DSP register writes are not implemented) and a type -1 remote code call with the $F4 $09 command.)</td>
+		<td rowspan="2">$FC $XX $01 $03 $00<br>
+along with a type -1 remote code call containing $F4 $09</td>
 		<td rowspan="2">Anticipation Gain<br></td>
 		<td rowspan="2">Sets the GAIN value of a voice whenever the note is keyed off.</td>
 		<td>$05 <br></td>
@@ -1149,7 +1170,8 @@ The highest command ID supported was $FC.
 	</tr>
 	<tr>
 		<td rowspan="2">$FC <br></td>
-		<td rowspan="2">N/A<br>(In general, this can be replicated for the most part using two remote code calls: a type 2 remote code call with the $F6 command (however, voice-specific DSP register writes are not implemented) and a type -1 remote code call with the $F4 $09 command.)</td>
+		<td rowspan="2">$FC $YY $01 $02 $XX<br>
+along with a type -1 remote code call containing $F4 $09</td>
 		<td rowspan="2">Remote Gain<br></td>
 		<td rowspan="2">Sets the GAIN value of a voice some time before a note ends.</td>
 		<td>$XX <br></td>

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -1662,10 +1662,10 @@ void Music::parseHexCommand()
 
 				return;
 			}
-			else if (targetAMKVersion > 1 && currentHex == 0xFC)
-			{
-				error("$FC has been replaced with remote code in #amk 2 and above.")
-			}
+			//else if (targetAMKVersion > 1 && currentHex == 0xFC)
+			//{
+			//	error("$FC has been replaced with remote code in #amk 2 and above.")
+			//}
 			else
 			{
 				hexLeft = hexLengths[currentHex - 0xDA] - 1;


### PR DESCRIPTION
This not only makes things easier for me to properly restore the original remote
gain-like functionality, but by assigning it to a high byte of $01 in the
pointer, it ensures it only blocks off variable ARAM only from being used...
including where the stack is located.

This merge request closes #88.