### PR TITLE
Fix bad pitch base fractional write caused by .clearSubmultiplierPatchGate

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -52,8 +52,8 @@ MSampleLoad:
 	mov	y, #$04			; | Get the pitch multiplier byte.
 	mov	($10)+y, a		; |
 .clearSubmultiplierPatchGate		; |
-	inc	y			; | Zero out pitch sub-multiplier.
 	bra	.clearSubmultiplierSkip	; |
+	inc	y			; | Zero out pitch sub-multiplier.
 	mov	a, #$00			; |
 	mov	($10)+y, a		; /
 .clearSubmultiplierSkip


### PR DESCRIPTION
A bad byte write here caused a corruption of the pitch base fractional
multiplier down the road caused by the hot patch VCMD.

This commit closes #315.