### PR TITLE
Correct a fault when searching for samples in the music's directory

### DIFF
--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -627,7 +627,7 @@ int getSample(const File &name, Music *music)
 	relativeDir += "/" + (std::string)name;
 
 	if (fileExists(relativeDir))
-		actualPath = relativeDir + (std::string)name;
+		actualPath = relativeDir;
 	else if (fileExists(absoluteDir))
 		actualPath = absoluteDir;
 	else


### PR DESCRIPTION
Turns out this method was supposed to be legal in the first place, but due to a
fault in the way the actual path was constructed from the relative directory, it
as never functional in the first place.

This merge request closes #319.