### PR TITLE
Always check whether or not noise is still in use when a SFX instance ends

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -756,15 +756,16 @@ endif
 	tclr	!SFXNoiseChannels, a	; / Turn noise off for this channel's SFX.
 
 	call	EffectModifier
+	mov	a, !SFXNoiseChannels
 if !noiseFrequencySFXInstanceResolution = !true
-	cmp	!SFXNoiseChannels, #$00
 	beq	.restoreMusicNoise
 	call	SetSFXNoise
 	call	ModifyNoise
 	bra	RestoreInstrumentInformation
+else
+	bne	RestoreInstrumentInformation
 endif
 .restoreMusicNoise:
-	mov	a, #$00
 	mov	$1f, a
 if !useSFXSequenceFor1DFASFX = !false
 	bbc!1DFASFXChannel	$18, +


### PR DESCRIPTION
The music noise frequency was being prematurely restored when the frequency of a SFX instance was not being checked. Thus, some code has to be added back in order to ensure this doesn't happen, though the branch opcode is different.

This merge request closes #327.