### PR TITLE
Optimize out the utilization of GetSampleTableAddress on SPC side

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -3494,30 +3494,7 @@ if !PSwitchIsSFX = !true
 	mov	$1b, #$00
 endif	
 JumpToUploadLocation:
-	jmp	($0014+x)		; Jump to address
-	
-GetSampleTableLocation:
-
-	print "SRCNTableCodePos: $",pc		
-				; This is where the engine should jump to after uploading samples.
-
--	cmp	$f4, #$CC	; Wait for the 5A22 to send #$CC to $2140.
-	bne -			; By then it should have also written DIR to $2141
-				; as well as the jump address to $2142-$2143.
-				
-	mov	a, #$5d
-	mov	y, $f5		; Set DIR to the 5A22's $2141
-	movw	$f2, ya
-	push	y
-	
-	movw	ya, $f6
-	movw	$14, ya
-	mov	$f1, #$31		; Reset input ports
-	pop	a
-	mov	$f5, a		; Echo back DIR
-	mov	y, #$00
-	bra	JumpToUploadLocation	; Jump to the upload location.
-	
+	jmp	($0014+x)		; Jump to address	
 
 	incsrc "InstrumentData.asm"
 	

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -462,7 +462,6 @@ void assembleSPCDriver()
 	openTextFile("temp.txt", temptxt);
 	mainLoopPos = scanInt(temptxt, "MainLoopPos: ");
 	reuploadPos = scanInt(temptxt, "ReuploadPos: ");
-	SRCNTableCodePos = scanInt(temptxt, "SRCNTableCodePos: ");
 	noSFX = (temptxt.find("NoSFX is enabled") != -1);
 	if (sfxDump && noSFX) {
 		printWarning("The sound driver build does not support sound effects due to the !noSFX flag\r\nbeing enabled in asm/UserDefines.asm, yet you requested to dump SFX. There will\r\nbe no new SPC dumps of the sound effects since the data is not included by\r\ndefault, nor is the playback code for the sound effects.");
@@ -1694,7 +1693,6 @@ void assembleSNESDriver2()
 	openTextFile("asm/SNES/patch.asm", patch);
 
 	insertValue(reuploadPos, 4, "!ExpARAMRet = ", patch);
-	insertValue(SRCNTableCodePos, 4, "!TabARAMRet = ", patch);
 	insertValue(mainLoopPos, 4, "!DefARAMRet = ", patch);
 	insertValue(songCount, 2, "!SongCount = ", patch);
 

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -49,7 +49,6 @@ int programPos;
 int programUploadPos;
 int mainLoopPos;
 int reuploadPos;
-int SRCNTableCodePos;
 int programSize;
 int highestGlobalSong;
 int totalSampleCount;

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -88,7 +88,6 @@ extern int programPos;
 extern int programUploadPos;
 extern int reuploadPos;
 extern int mainLoopPos;
-extern int SRCNTableCodePos;
 extern int programSize;
 extern int highestGlobalSong;
 //extern int totalSampleCount;


### PR DESCRIPTION
This optimization required modifications to the C++ side (to remove the setting of !TabARAMRet), the SNES side (to replace the sample directory setup code) and the SPC side (to remove the routine).

The sample directory setup can be simplified into storing the DSP register writes into scratch RAM, then sending it as a two-byte block into $F2 on the SPC side, which writes it directly to the DSP register specified. I've seen this technique used before straight out of the IPL Boot ROM, and since this sound driver uses a variant of that, it means I can use the same technique here.

This merge request closes #326.