### PR TITLE
Have remote gain play nice with SFX

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -13,7 +13,9 @@ TerminateIfSFXPlaying:
 endif
 
 SetBackupSRCN:
-	mov	a, #$01			; \ Force !BackupSRCN to contain a non-zero value.
+	mov	a, #$40			; \ Force !BackupSRCN to contain a non-zero value.
+ORBackupSRCN:
+	or	a, !BackupSRCN+x	; |
 	mov	!BackupSRCN+x, a	; /
 	ret
 

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -833,10 +833,11 @@ RestoreInstrumentInformation:		; \ Call this with x = currentchannel*2 to restor
 	call	SetInstrument		; |
 .checkRemoteGainRestoration		; |
 	pop	p			; |
-	bpl	.doneRestoring		; | Fix remote gain.
+	bpl	.doneRestoringNoPop	; | Fix remote gain.
 	jmp    RestoreRemoteGain	; /
 .doneRestoring				;
 	pop	p			;
+.doneRestoringNoPop			;
 	ret				;
 					;
 .restoreSample				; \ 

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -313,7 +313,10 @@ RunRemoteCode_Exec:
 	mov	$30+x, y
 	mov	$31+x, a
 	dec	a
-	beq	UseGainInstead
+	bne	+
+	call	UseGainInstead
+	bra	RestoreTrackPtrFromStack
++
 	mov	a, #$6f			;RET opcode
 	mov	runningRemoteCodeGate, a
 	call	L_0C57			; This feels evil.  Oh well.  At any rate, this'll run the code we give it.
@@ -339,6 +342,17 @@ RunRemoteCode2:
 }
 
 UseGainInstead:
+	setp
+	mov	$0170&$FF+x, y
+	clrp
+	mov	a, #$80
+	call	ORBackupSRCN
+if !noSFX = !false
+	call	TerminateIfSFXPlaying
+endif
+RestoreRemoteGain:
+	mov	a, $0170+x
+	mov	y, a
 	mov	a, x			; \
 	lsr	a			; | GAIN Register into a
 	xcn	a			; |
@@ -348,7 +362,7 @@ UseGainInstead:
 	dec	a			; | Clear ADSR bit to force GAIN.
 	mov	y, #$7f			; |
 	movw	$f2, ya			; /
-	bra	RestoreTrackPtrFromStack
+	ret
 
 CheckForRemoteCodeType6:
 	mov	a, #$06
@@ -412,6 +426,9 @@ endif
 	cmp	a, !remoteCodeType+x
 	bne	.checkRemoteCodeTypes
 .remoteCodeRestoreInstrumentOnKON
+	mov	a, #$7F			; \ Don't restore remote gain.
+	and	a, !BackupSRCN+x	; | Instead, restore either the
+	mov	!BackupSRCN+x, a	; / instrument or the sample.
 	call	RestoreInstrumentInformation
 
 .checkRemoteCodeTypes
@@ -803,19 +820,28 @@ endif
 
 	mov	x, $46			; \ 
 endif
-RestoreInstrumentInformation:		; Call this with x = currentchannel*2 to restore all instrument properties for that channel.
+
+RestoreInstrumentInformation:		; \ Call this with x = currentchannel*2 to restore all instrument properties for that channel.
 	
 	mov	a, !BackupSRCN+x	; |
-	bne	.restoreSample		; |
+	push	p			; |
+	asl	a			; |
+	bmi	.restoreSample		; |
 	mov	a, $c1+x		; | Fix instrument.
-	beq	+			; |
+	beq	.doneRestoring		; |
 	dec	a			; |
-	jmp	SetInstrument		; |
-+					; /
+	call	SetInstrument		; |
+.checkRemoteGainRestoration		; |
+	pop	p			; |
+	bpl	.doneRestoring		; | Fix remote gain.
+	jmp    RestoreRemoteGain	; /
+.doneRestoring				;
+	pop	p			;
 	ret				;
 					;
 .restoreSample				; \ 
-	jmp   RestoreMusicSample	; / Fix sample.
+	call   RestoreMusicSample	; / Fix sample.
+	bra	.checkRemoteGainRestoration
 }
 
 SubC_9:
@@ -835,7 +861,8 @@ HandleSFXVoice:
 +
 .getMoreSFXData
 	call	GetNextSFXByte		
-	beq	EndSFX			; If the current byte is zero, then end it.
+	bne	+			; If the current byte is zero, then end it.
+	jmp	EndSFX
 +
 	bmi	.noteOrCommand		; If it's negative, then it's a command or note.
 	mov	!ChSFXNoteTimerBackup+x, a			

--- a/readme_files/aram_map.html
+++ b/readme_files/aram_map.html
@@ -587,7 +587,21 @@ Romi's Addmusic (Addmusic404)'s custom code used no new memory locations, and th
 				<td>AddmusicK<br>(Moved from $0167 in AddmusicM, but only from where it outputs: the music tempo tick usage doesn't carry over here)</td>
 			</tr>
 			<tr>
-				<td>$016A-$018F</td>
+				<td>$016A-$016F</td>
+				<td colspan="3"><div style="text-align:center; font-weight: bold;">Unused.</div></td>
+			</tr>
+			<tr>
+				<td>$0170, $0172, $0174, $0176, $0178, $017A, $017C, $017E</td>
+				<td>Backup remote gain values, in case they are overwritten by SFX. One byte per voice.</td>
+				<td>N/A</td>
+				<td>New</td>
+			</tr>
+			<tr>
+				<td>$0171, $0173, $0175, $0177, $0179, $017B, $017D, $017F</td>
+				<td colspan="3"><div style="text-align:center; font-weight: bold;">Unused.</div></td>
+			</tr>
+			<tr>
+				<td>$0180-$018F</td>
 				<td colspan="3"><div style="text-align:center; font-weight: bold;">Unused.</div></td>
 			</tr>
 			<tr>
@@ -668,9 +682,21 @@ Romi's Addmusic (Addmusic404)'s custom code used no new memory locations, and th
 			</tr>
 			<tr>
 				<td>$0220, $0222, $0224, $0226, $0228, $022A, $022C, $022E</td>
+				<td>Contains various flags for various purposes, stored as %xy??????. One byte per voice.<br>See below for a list of bits whose usages don't match the latest version.</td>
+				<td>N/A</td>
+				<td>New<br>(At least one of the bits dates back to AddmusicK representing the entire byte, but was moved)</td>
+			</tr>
+			<tr>
+				<td>$0220, $0222, $0224, $0226, $0228, $022A, $022C, $022E bit 6 (%?y??????)</td>
 				<td>Flag indicating that instrument data has been modified, and thus must be restored via the backup tables at $0130-$015F. One byte per voice.</td>
 				<td>N/A</td>
-				<td>AddmusicK</td>
+				<td>New<br>(was also in AddmusicK representing the entire byte)</td>
+			</tr>
+			<tr>
+				<td>$0220, $0222, $0224, $0226, $0228, $022A, $022C, $022E bit 7 (%x???????)</td>
+				<td>Flag indicating that remote gain has been used, and thus must be restored via the backup tables at $0170, $0172, $0174, $0176, $0178, $017A, $017C, $017E. One byte per voice.</td>
+				<td>N/A</td>
+				<td>New</td>
 			</tr>
 			<tr>
 				<td>$0221, $0223, $0225, $0227, $0229, $022B, $022D, $022F</td>
@@ -1057,6 +1083,12 @@ Romi's Addmusic (Addmusic404)'s custom code used no new memory locations, and th
 				<th>Description</th>
 				<th>Moved From</th>
 				<th>Moved To</th>
+			</tr>
+			<tr>
+				<td>$0220, $0222, $0224, $0226, $0228, $022A, $022C, $022E</td>
+				<td>Flag indicating that instrument data has been modified, and thus must be restored via the backup tables at $0130-$015F. One byte per voice.</td>
+				<td>N/A (New)</td>
+				<td>$0220, $0222, $0224, $0226, $0228, $022A, $022C, $022E bit 6 (%?y??????)</td>
 			</tr>
 			<tr>
 				<td>$0380</td>


### PR DESCRIPTION
Currently there is no code to handle remote gain with SFX. AddmusicK Beta didn't have this problem, but now that it is supported across all remote code types, it can be a problem when interacting with the SFX. One of the memory locations has been repurposed to be multi-bit in order to ensure that the restoration only happens when it needs to.

This commit closes #331.