### PR TITLE
Change negative note errors into a warning for #amk 3 and earlier

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -95,6 +95,7 @@ static bool caseNoteWarning;
 static bool octaveForDDWarning;
 static bool remoteGainWarning;
 static bool fractionNoteLengthWarning;
+static bool lowNoteWarning;
 
 static bool channelDefined;
 //static int am4silence;			// Used to keep track of the brief silence at the start of am4 songs.
@@ -190,6 +191,7 @@ void Music::init()
 	caseNoteWarning = true;
 	remoteGainWarning = true;
 	fractionNoteLengthWarning = true;
+	lowNoteWarning = true;
 	tempoDefined = false;
 	//am4silence = 0;
 	//songVersionIdentified = false;
@@ -2132,11 +2134,16 @@ void Music::parseNote()
 				i -= transposeMap[instrument[channel]];
 		}
 
-
 		if (i < 0x80)
 		{
-			error("Note's pitch was too low.")
+			if (songTargetProgram == 0 && targetAMKVersion < 4 && lowNoteWarning) {
+				printWarning("WARNING: This older AddmusicK song outputs an invalid note byte (its pitch is too low)! It may not be audible in the song!", name, line);
+				lowNoteWarning = false; 
+			}
+			else {
+				error("Note's pitch was too low.");
 				i = 0xC7;
+			}
 		}
 		else if (i >= 0xC6)
 		{


### PR DESCRIPTION
When I fixed the detection of the pitch, I accidentally broke some older ports that would have technically worked due to a loophole in how a note byte was detected. They have been allowed again, but with a warning, as the note would otherwise likely not be audible under normal circumstances due to other problems with the pitch calculation.

This commit closes #338.