### PR TITLE
Skip merging notes and ties on past Addmusics

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2203,8 +2203,9 @@ void Music::parseNote()
 		int tempsize = j;	// If there's a pitch bend up ahead, we need to not optimize the last tie.
 		int temppos = pos;	//
 
-		if (j != 0 && (text[pos] == '^' || (i == 0xC7 && text[pos] == 'r')))
+		if (j != 0 && ((((songTargetProgram == 0 && targetAMKVersion != 0) || i == 0xC7) && text[pos] == '^') || (i == 0xC7 && text[pos] == 'r'))) {
 			pos++;
+		}
 
 		j += getNoteLength(getInt());
 		skipSpaces;
@@ -2220,7 +2221,7 @@ void Music::parseNote()
 		if (pos >= text.length())
 			break;
 
-	} while (text[pos] == '^' || (i == 0xC7 && text[pos] == 'r'));
+	} while ((((songTargetProgram == 0 && targetAMKVersion != 0) || i == 0xC7) && text[pos] == '^') || (i == 0xC7 && text[pos] == 'r'));
 
 	/*if (normalLoopInsideE6Loop)
 	tempLoopLength += j;


### PR DESCRIPTION
Rests are allowed to be merged together, but notes and ties are not. This is because of a conflict with quantization: quantization acts relative to the length of the last VCMD executed, and ties are separated from normal notes in this specific situation. Without doing this, notes may key off sooner than expected compared to the way they were originally created. Rests can still be merged together because it is already keyed off to begin with.

This merge request closes #350.