### PR TITLE
Clear surround settings on song initialization

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2131,6 +2131,7 @@ L_0B6D:
 	mov	a, #$ff
 	mov	!Volume+x, a         ; Volume[ch] = #$FF
 	inc	a
+	mov	!SurroundSound+x, a
 	mov	$0280+x, a
 	mov	$02d1+x, a         ; Tuning[ch] = 0
 	mov	!PanFadeDuration+x, a           ; PanFade[ch] = 0


### PR DESCRIPTION
Another parameter that wasn't cleared out should have been cleared out, given that failure to use any panning VCMDs would result in surround settings accidentally being carried over.

This merge request closes #353.