### PR TITLE
Use !EchoDelay instead of the EDL DSP register + add some NOPs while waiting

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2618,9 +2618,11 @@ ModifyEchoDelay:			; a should contain the requested delay.  Normally only called
 	mov	$f3, y			; Wait for the echo buffer to be "captured" in a four byte area at the beginning before modifying the ESA and EDL DSP registers.
 	xcn	a			; This ensures it can be safely reallocated without risking overwriting the program.
 	lsr	a			; This requires waiting for at least the amount of time it takes for the old EDL value to complete one buffer write loop.
-	movw	$14, ya
+	movw	$14, ya			; Consume at least eight cycles per iteration. 
 -
-	dbnz	$15, -
+	nop				; This is because the echo buffer writes four bytes per sample (or 32 cycles in this case).
+	nop				; NOP is 2 cycles.
+	dbnz	$15, -			; 7 cycles per DBNZ (except for the last iteration, which subtracts two cycles)
 	dbnz	$14, -
 +
 	

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2610,10 +2610,10 @@ ModifyEchoDelay:			; a should contain the requested delay.  Normally only called
 	mov	$f2, #$6c
 	or	$f3, #$60
 
-	mov	$f2, #$7d
-	mov	a, $f3
+	mov	a, !EchoDelay
 	and	a, #$0f
 	beq	+
+	mov	$f2, #$7d
 	mov	$f3, #$00		; Wait for the echo buffer to be "captured" in a four byte area at the beginning before modifying the ESA and EDL DSP registers.
 	xcn	a			; This ensures it can be safely reallocated without risking overwriting the program.
 	lsr	a			; This requires waiting for at least the amount of time it takes for the old EDL value to complete one buffer write loop.

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2624,8 +2624,8 @@ ModifyEchoDelay:			; a should contain the requested delay.  Normally only called
 +
 	
 	pop	y			; \
-	clr1	$f2.4			; | Write the new buffer address.
-	mov	$f3, y			; / 
+	mov	a, #$6d			; | Write the new buffer address.
+	movw	$f2, ya			; / 
 	
 	pop	a
 	call	SetEDLVarDSP		; Write the new delay.

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2614,13 +2614,14 @@ ModifyEchoDelay:			; a should contain the requested delay.  Normally only called
 	and	a, #$0f
 	beq	+
 	mov	$f2, #$7d
-	mov	$f3, #$00		; Wait for the echo buffer to be "captured" in a four byte area at the beginning before modifying the ESA and EDL DSP registers.
+	mov	y, #$00
+	mov	$f3, y			; Wait for the echo buffer to be "captured" in a four byte area at the beginning before modifying the ESA and EDL DSP registers.
 	xcn	a			; This ensures it can be safely reallocated without risking overwriting the program.
 	lsr	a			; This requires waiting for at least the amount of time it takes for the old EDL value to complete one buffer write loop.
-	mov	$14, #$00
-	mov	$15, a
--	dbnz	$14, -
+	movw	$14, ya
+-
 	dbnz	$15, -
+	dbnz	$14, -
 +
 	
 	pop	y			; \


### PR DESCRIPTION
A couple of things were done along with some optimizations to ensure no ASM filesize changes occurred.
First off, !EchoDelay is now used again, because it is not updated when the loader is called up.

This pull request closes #357.

Note that this can be upgraded. Currently the upgrade imposes a delay when a new song starts up and the buffer is being allocated for the first time, which is the same general behavior as 1.0.8. There are two paths possible:
- Have the program wait for the echo to sync up before loading. This transfers the delay to just before the loader, and eliminates startup lag for the music. However, this adds waiting for the echo to the loading time. The EDL is already set to zero just before the loader, so we do have that helping us out. This would involve splitting the echo waiting into its own routine (restoring the WaitForDelay label in the process) and then inserting two calls: one where it's waiting now, and one just before jumping to the loader.
- Use the hardware timer to keep track of time while loading new data. This is more complicated and slightly slows down loading, but the end result is that startup delays can be bypassed for the music. However, this may need a SNES-side modification so that it can properly track an acknowledgement signal ($2141/$F5 cleared in this case) rather than use NOPs because there is now an inconsistent delay between the end of loading and when the sound driver is ready to play music again.