### PR TITLE
Avoid uname, it breaks on appveyor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,7 @@
 #version at this time unless you're using Wine or some other emulation
 #layer)
 
-UNAME := $(shell uname -s)
-
-$(info $UNAME is $(UNAME))
-
-ifneq (,$(findstring MSYS,$(UNAME)))
+ifeq ($(OS),Windows_NT)
 #Windows setting (made for MinGW, though in hindsight this may be a bad call)...
 	CXX = x86_64-w64-mingw32-g++
 else
@@ -26,7 +22,7 @@ CXXFLAGS = -Wall -pedantic -std=c++17 -Os
 #with libboost (this specifically targets MacPorts inclusions)
 #CXXFLAGS += -I/opt/local/include
 
-ifneq (,$(findstring MSYS,$(UNAME)))
+ifeq ($(OS),Windows_NT)
 #Windows setting...
 	LDFLAGS = -static -static-libgcc -static-libstdc++ -s
 else


### PR DESCRIPTION
Looks like a bug on appveyor's side, but easier to fix here than wait for them to fix it.

If you want to distinguish mac from linux, consider $(shell $(CXX) -dumpmachine).