### PR TITLE
Don't output an error on multiple low note warnings

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -2150,9 +2150,11 @@ void Music::parseNote()
 
 		if (i < 0x80)
 		{
-			if (songTargetProgram == 0 && targetAMKVersion < 4 && lowNoteWarning) {
-				printWarning("WARNING: This older AddmusicK song outputs an invalid note byte (its pitch is too low)! It may not be audible in the song!", name, line);
-				lowNoteWarning = false; 
+			if (songTargetProgram == 0 && targetAMKVersion < 4) {
+				if (lowNoteWarning) {
+					printWarning("WARNING: This older AddmusicK song outputs an invalid note byte (its pitch is too low)! It may not be audible in the song!", name, line);
+					lowNoteWarning = false; 
+				}
 			}
 			else {
 				error("Note's pitch was too low.");


### PR DESCRIPTION
The error is only supposed to happen on specific parser versions instead of if the warning was already output.

This commit closes #375.