### PR TITLE
Fix for music being reset when having P-Switch and/or Star equals #$00 in UserDefines

### DIFF
--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -178,7 +178,7 @@ YoshiDrumHijack:
 		BEQ NoYoshiDrum
 		LDA $1B9B|!SA1Addr2
 		BNE NoYoshiDrum
-		JSL $00FC7A
+		JSL $00FC7A|!Bank
 		PLB
 		RTL
 NoYoshiDrum:


### PR DESCRIPTION
This is more of a niche use case but these changes make AMK skip the PSwitch/Star checks on the SNES side if they're set to #$00 in UserDefines. Previously the code would just set the music mirror to $00 every frame, preventing user code from having changes to $1DFB take effect while a P-Switch and/or Star is going off. While this is not a super common scenario, it might be useful for having certain levels have custom P-Switch/Star tracks (while they're disabled globally), or something like that.
Note that the check is very ugly due to the defines having "#" (I'm comparing the strings, which will break if the user uses "#0" instead of "#$00", for example). Might be worth changing the defines to not include the "#" in the future.
Additionally I noticed there were a couple of long addresses that weren't mirrored to banks $80+ in case of fastrom, so I added |!Bank for those to speedup the code when not using SA-1.
Also, sorry for the plethora or changes that don't seem to do anything, it seems like the asm files have some weird or inconsistent line endings which my editor changed automatically in some spots.