### PR TITLE
Make all numeric defines not use # at the beginning

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -218,7 +218,7 @@ endif
 if !PSwitchStarRestart == !true
 +	lda #$01
 	sta !Trick
-	lda !Tricker
+	lda #!Tricker
 	sta !MusicReg
 	bra End
 endif
@@ -237,43 +237,43 @@ ChangeMusic:
 	
 ;	LDA !MusicMir
 if !PSwitchIsSFX = !false
-;	CMP !PSwitch
+;	CMP #!PSwitch
 ;	BEQ .doExtraChecks
 endif
-;	CMP !Starman
+;	CMP #!Starman
 ;	BEQ .doExtraChecks
 ;	BRA .okay
 ;	
 ;.doExtraChecks			; We can't allow the p-switch or starman songs to play during the level clear themes.
 	LDA !CurrentSong
-	CMP !StageClear
+	CMP #!StageClear
 	BEQ LevelEndMusicChange
-	CMP !IrisOut
+	CMP #!IrisOut
 	BEQ LevelEndMusicChange
-	CMP !Keyhole
+	CMP #!Keyhole
 	BEQ LevelEndMusicChange
-	CMP !BossClear		;;; this one too
+	CMP #!BossClear		;;; this one too
 	BNE Okay
 	
 LevelEndMusicChange:
 	LDA !MusicMir
-	CMP !IrisOut
+	CMP #!IrisOut
 	BEQ Okay
-	CMP !SwitchPalace	;;; bonus game fix
+	CMP #!SwitchPalace	;;; bonus game fix
 	BEQ Okay
-	CMP !Miss		;;; sure why not
+	CMP #!Miss		;;; sure why not
 	BEQ Okay
-	CMP !RescueEgg
+	CMP #!RescueEgg
 	BEQ Okay		; Yep
-	CMP !StaffRoll	; Added credits check
+	CMP #!StaffRoll	; Added credits check
 	BEQ Okay
 	LDA $0100|!SA1Addr2		
 	CMP #$10			
 	BCC Okay
 	;;; LDA !CurrentSong	;;; this is why we got here in first place, seems redundant
-	;;; CMP !StageClear
+	;;; CMP #!StageClear
 	;;; BEQ EndWithCancel
-	;;; CMP !IrisOut
+	;;; CMP #!IrisOut
 	;;; BEQ EndWithCancel
 EndWithCancel:
 if !PSwitchStarRestart == !false
@@ -292,10 +292,10 @@ Okay:
 	
 	LDA !CurrentSong		; \ 
 if !PSwitchIsSFX = !false
-	CMP !PSwitch			; |
+	CMP #!PSwitch			; |
 	BEQ +				; |
 endif
-	CMP !Starman			; |
+	CMP #!Starman			; |
 	BNE ++				; | Don't upload samples if we're coming back from the pswitch or starman musics.
 	;;;BRA ++			; |
 +					; |
@@ -316,9 +316,9 @@ endif
 ;	CMP #$0F
 ;	BCC .forceMusicToPlay
 ;	LDA !CurrentSong
-;	CMP !StageClear
+;	CMP #!StageClear
 ;	BEQ EndWithCancel
-;	CMP !IrisOut
+;	CMP #!IrisOut
 ;	BEQ EndWithCancel
 ;.forceMusicToPlay
 
@@ -623,17 +623,17 @@ HandleSpecialSongs:
 	CMP #$0F
 	BEQ +
 	LDA !MusicMir
-	CMP !Miss
+	CMP #!Miss
 	BEQ +
-	CMP !GameOver
+	CMP #!GameOver
 	BEQ +
-	CMP !StageClear		;;; more checks here should help
+	CMP #!StageClear	;;; more checks here should help
 	BEQ ++
-	CMP !IrisOut
+	CMP #!IrisOut
 	BEQ ++
-	CMP !BossClear
+	CMP #!BossClear
 	BEQ ++
-	CMP !Keyhole
+	CMP #!Keyhole
 	BEQ ++
 	LDA $14AD|!SA1Addr2
 	ORA $14AE|!SA1Addr2
@@ -667,10 +667,10 @@ if !PSwitchStarRestart == !true
 	bcs .starMusic			;;; just play the star music
 if !PSwitchIsSFX = !false
 	lda !MusicMir
-	cmp !PSwitch
+	cmp #!PSwitch
 	beq ++
 	lda !CurrentSong
-	cmp !PSwitch
+	cmp #!PSwitch
 	bne +
 endif
 
@@ -678,7 +678,7 @@ endif
 	rts
 
 if !PSwitchIsSFX = !false
-+	LDA !PSwitch
++	LDA #!PSwitch
 	STA !MusicMir
 ++	RTS
 endif
@@ -690,7 +690,7 @@ else
 endif
 
 if !PSwitchIsSFX = !false && !PSwitchStarRestart == !false
-	LDA !PSwitch
+	LDA #!PSwitch
 	STA !MusicMir
 endif
 ++
@@ -701,16 +701,16 @@ if !PSwitchStarRestart == !true
 	jsr SkipPowStar
 	bcs ++
 	lda !MusicMir
-	cmp !Starman
+	cmp #!Starman
 	beq ++
 	lda !CurrentSong
-	cmp !Starman
+	cmp #!Starman
 	bne +
 	stz !MusicMir
 	rts
 endif
 
-+	LDA !Starman
++	LDA #!Starman
 	STA !MusicMir
 ++	RTS
 
@@ -724,13 +724,13 @@ endif
 if !PSwitchStarRestart == !true
 SkipPowStar:
 	lda !CurrentSong
-	cmp !StageClear
+	cmp #!StageClear
 	beq +
-	cmp !IrisOut
+	cmp #!IrisOut
 	beq +
-	cmp !BossClear
+	cmp #!BossClear
 	beq +
-	cmp !Keyhole
+	cmp #!Keyhole
 	beq +
 	clc
 +	rts

--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -40,7 +40,7 @@ if !PSwitchIsSFX = !true
 +
 else
 	BEQ +
-	LDX.B !PSwitch
+	LDX.B #!PSwitch
 +
 endif
 
@@ -66,7 +66,7 @@ if !PSwitchIsSFX = !true
 Skip10:
 else
 Skip10:
-	LDA.B !PSwitch
+	LDA.B #!PSwitch
 	STA $1DFB|!SA1Addr2
 endif
 
@@ -87,7 +87,7 @@ if !PSwitchIsSFX = !true
 	LDA.b #$C0
 	STA $1DFC|!SA1Addr2
 else
-	LDA.b !PSwitch
+	LDA.b #!PSwitch
 	STA $1DFB|!SA1Addr2
 endif
 
@@ -135,7 +135,7 @@ org $0CA5C2
 	db !CastList
 		
 org $009723
-	LDA.b !Welcome
+	LDA.b #!Welcome
 	STA.w $0DDA|!SA1Addr2					
 	LDA.w $0DDA|!SA1Addr2	; 
 	NOP : NOP		; 
@@ -143,7 +143,7 @@ org $009723
 	LDY.w $0D9B|!SA1Addr2	; 
 	CPY.b #$C1		; 
 	BNE CODE_009738		; 
-	LDA.b !Bowser		; 
+	LDA.b #!Bowser		; 
 CODE_009738:			;
 	STA.w $1DFB|!SA1Addr2	; 
 CODE_00973B:			;
@@ -342,7 +342,7 @@ Skip9:
 org $01C585	; 13 bytes
 	;LDA $1DFB|!SA1Addr2
 	;STA $0DDA|!SA1Addr2
-	LDA !Starman
+	LDA #!Starman
 	STA $1DFB|!SA1Addr2
 	RTL
 	
@@ -366,7 +366,7 @@ org $00805E			; Don't upload the standard sample bank.
 	NOP : NOP : NOP
 	
 org $0093C0
-LDA.b !NintPresents
+LDA.b #!NintPresents
 STA $1DFB|!SA1Addr2
 
 

--- a/asm/UserDefines.asm
+++ b/asm/UserDefines.asm
@@ -135,20 +135,20 @@ includeonce
 
 ;=======================================
 ;---------------
-!JumpSFX1DFAPriority = #$00
+!JumpSFX1DFAPriority = $00
 
-;Default setting: #$00
-;Vanilla SMW setting: #$20
+;Default setting: $00
+;Vanilla SMW setting: $20
 ;---------------
 ; Sets the priority for the jump SFX in 1DFA.
 ;=======================================
 
 ;=======================================
 ;---------------
-!GirderSFX1DFAPriority = #$00
+!GirderSFX1DFAPriority = $00
 
-;Default setting: #$00
-;Vanilla SMW setting: #$10
+;Default setting: $00
+;Vanilla SMW setting: $10
 ;---------------
 ; Sets the priority for the girder SFX in 1DFA.
 ;=======================================
@@ -232,46 +232,46 @@ includeonce
 ; If you've changed list.txt and plan on using the original SMW songs
 ; change these constants to whatever they are in list.txt
 ; For example, if you changed the "Stage Clear" music to be number 9,
-; Then you'd change "!StageClear = #$04" to "!StageClear = #$09".
-!Starman	= #$05
-!Miss		= #$01			
-!GameOver	= #$02			
-!BossClear	= #$03			
-!StageClear	= #$04			
-!PSwitch	= #$06
-!Keyhole	= #$07
-!IrisOut	= #$08
-!BonusEnd	= #$09
-!Piano		= #$0A
-!HereWeGo	= #$0B
-!Water		= #$0C
-!Bowser		= #$0D
-!Boss		= #$0E
-!Cave		= #$0F
-!GhostHouse	= #$10
-!Castle		= #$11
-!SwitchPalace	= #$12
-!Welcome	= #$13
-!RescueEgg	= #$14
-!Title		= #$15
-!VoBAppears	= #$16
-!Overworld	= #$17
-!YoshisIsland	= #$18
-!VanillaDome	= #$19
-!StarRoad	= #$1A
-!ForestOfIllusion = #$1B
-!ValleyOfBowser	= #$1C
-!SpecialWorld	= #$1D
-!NintPresents   = #$1E		; Note that this is a song, not a sound effect!
+; Then you'd change "!StageClear = $04" to "!StageClear = $09".
+!Starman	= $05
+!Miss		= $01			
+!GameOver	= $02			
+!BossClear	= $03			
+!StageClear	= $04			
+!PSwitch	= $06
+!Keyhole	= $07
+!IrisOut	= $08
+!BonusEnd	= $09
+!Piano		= $0A
+!HereWeGo	= $0B
+!Water		= $0C
+!Bowser		= $0D
+!Boss		= $0E
+!Cave		= $0F
+!GhostHouse	= $10
+!Castle		= $11
+!SwitchPalace	= $12
+!Welcome	= $13
+!RescueEgg	= $14
+!Title		= $15
+!VoBAppears	= $16
+!Overworld	= $17
+!YoshisIsland	= $18
+!VanillaDome	= $19
+!StarRoad	= $1A
+!ForestOfIllusion = $1B
+!ValleyOfBowser	= $1C
+!SpecialWorld	= $1D
+!NintPresents   = $1E		; Note that this is a song, not a sound effect!
 
-!Bowser2	= #$1F		;
-!Bowser3	= #$20
-!BowserDefeated = #$21
-!BowserIntrlude = #$22
-!BowserZoomIn	= #$23
-!BowserZoomOut	= #$24
-!PrincessSaved	= #$25
-!StaffRoll	= #$26
-!YoshisAreHome	= #$27
-!CastList	= #$28
+!Bowser2	= $1F		;
+!Bowser3	= $20
+!BowserDefeated = $21
+!BowserIntrlude = $22
+!BowserZoomIn	= $23
+!BowserZoomOut	= $24
+!PrincessSaved	= $25
+!StaffRoll	= $26
+!YoshisAreHome	= $27
+!CastList	= $28
 ;=======================================

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1480,12 +1480,12 @@ CheckAPU1SFXPriority:
 	;mov	y, #$00		;Default priority
 	cmp	a, #$01
 	bne	+
-	mov	y, !JumpSFX1DFAPriority		;Priority for jump SFX
+	mov	y, #!JumpSFX1DFAPriority	;Priority for jump SFX
 	bra	.gotPriority
 +
 	;cmp	a, #$04
 	;bne	+
-	mov	y, !GirderSFX1DFAPriority	;Priority for girder SFX
+	mov	y, #!GirderSFX1DFAPriority	;Priority for girder SFX
 	;bra	.gotPriority
 +
 


### PR DESCRIPTION
These defines should not be using # at the beginning in order to avoid ambiguity between a constant and a memory location in the ASM files.

This merge request closes #379.