### PR TITLE
Move asar_init call to actually use the dynamic library (and update bindings)

### DIFF
--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -57,6 +57,10 @@ int main(int argc, char* argv[]) try		// // //
 	std::cout << "Parser version " << PARSER_VERSION << std::endl << std::endl;
 	std::cout << "Protip: Be sure to read the readme! If there's an error or something doesn't\nseem right, it may have your answer!\n\n" << std::endl;
 
+    if (asar_init() == false)
+        useAsarDLL = false;
+    else
+        useAsarDLL = true;
 
 	std::vector<std::string> arguments;
 
@@ -163,12 +167,6 @@ int main(int argc, char* argv[]) try		// // //
 			std::getline(std::cin, ROMName.filePath);
 			puts("\n\n");
 		}
-
-		if (asar_init() == false)
-			useAsarDLL = false;
-		else
-			useAsarDLL = true;
-
 
 
 		std::string tempROMName = ROMName.cStr();

--- a/src/AddmusicK/asardll.c
+++ b/src/AddmusicK/asardll.c
@@ -1,55 +1,137 @@
-#define NULL 0
-#ifdef _WIN32
-	#include <windows.h>
-	#define getlib() LoadLibrary("asar.dll")
-	#define loadraw(name, target) *((int(**)())&target)=(int(*)())GetProcAddress((HINSTANCE)asardll, name); require(target)
-	#define closelib(var) FreeLibrary((HINSTANCE)var)
-#else
-	#include <dlfcn.h>
-	#include <stdio.h>
-	#ifdef __APPLE__
-		#define EXTENSION ".dylib"
-	#else
-		#define EXTENSION ".so"
-	#endif
-	inline void * getlib()
+#include <stdbool.h>
+#include <stddef.h>
+
+#if defined(_WIN32)
+#	if defined(_MSC_VER)
+#		pragma warning(push)
+#		pragma warning(disable : 4255)
+#		pragma warning(disable : 4668)
+#	endif
+
+#	include <windows.h>
+#	include <stdio.h>
+
+#	if defined(_MSC_VER)
+#		pragma warning(pop)
+#	endif
+
+inline static void * getlib(void)
+{
+	void * ret_val = LoadLibraryW(L"asar.dll");
+
+	if (ret_val == NULL)
 	{
-		char libname[256];
-		const char * names[]={"./libasar" EXTENSION, "libasar", NULL};
+		// TODO: Add a better method of error checking? This won't do much for people who are using
+		// Asar with a GUI application, they probably won't see this error output.
+		char buf[1024];
+		sprintf(buf, "Failed to load Asar DLL! HRESULT: 0x%08x\n", (unsigned int)HRESULT_FROM_WIN32(GetLastError()));
+		printf("%s", buf);
+		OutputDebugStringA(buf);
+	}
+
+	return ret_val;
+}
+
+inline static void * getlibfrompath(const char * path)
+{
+	int required_size = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+	if (required_size <= 0) return NULL;
+
+	wchar_t* path_buf = (wchar_t*)malloc((size_t)required_size * sizeof(wchar_t));
+	if (path_buf == NULL) return NULL;
+
+	int converted_size = MultiByteToWideChar(CP_UTF8, 0, path, -1, path_buf, required_size);
+
+	if (converted_size == 0)
+	{
+		return NULL;
+	}
+
+	void * ret_val = LoadLibraryW(path_buf);
+	free(path_buf);
+
+	if (ret_val == NULL)
+	{
+		// TODO: Add a better method of error checking? This won't do much for people who are using
+		// Asar with a GUI application, they probably won't see this error output.
+		char buf[1024];
+		sprintf(buf, "Failed to load Asar DLL! HRESULT: 0x%08x\n", (unsigned int)HRESULT_FROM_WIN32(GetLastError()));
+		printf("%s", buf);
+		OutputDebugStringA(buf);
+	}
+
+	return ret_val;
+}
+
+inline static bool setfunction(void* target, FARPROC fn)
+{
+	memcpy(target, &fn, sizeof(fn));
+	return fn;
+}
+#	define loadraw(name, target) require(setfunction(&target, GetProcAddress((HINSTANCE)asardll, name)))
+#	define closelib(var) FreeLibrary((HINSTANCE)var)
+#else
+#	include <dlfcn.h>
+#	include <stdio.h>
+
+#	ifdef __APPLE__
+#		define EXTENSION ".dylib"
+#	else
+#		define EXTENSION ".so"
+#	endif
+
+	inline static void * getlib(void)
+	{
+		const char * names[]={"./libasar"EXTENSION, "libasar", NULL};
 		for (int i=0;names[i];i++)
 		{
 			void * rval=dlopen(names[i], RTLD_LAZY);
-const char*e=dlerror();if(e)puts(e);
+			const char*e=dlerror();
+			if(e)puts(e);
 			if (rval) return rval;
 		}
 		return NULL;
 	}
-	#define loadraw(name, target) *(void **)(&target)=dlsym(asardll, name); require(target)
-	#define closelib(var) dlclose(var)
+
+	inline static void * getlibfrompath(const char * path)
+	{
+		void * rval = dlopen(path, RTLD_LAZY);
+		const char*e = dlerror();
+		if (e)puts(e);
+		if (rval) return rval;
+		return NULL;
+	}
+
+#	define loadraw(name, target) *(void **)(&target)=dlsym(asardll, name); require(target)
+#	define closelib(var) dlclose(var)
 #endif
+
+#include "asardll.h"
+
+#undef asarfunc
+#undef ASAR_DLL_H_INCLUDED
+
 #define asarfunc
 #include "asardll.h"
 
 static void * asardll=NULL;
 
-static bool (*asar_i_init)();
-static void (*asar_i_close)();
+static bool (*asar_i_init)(void);
+static void(*asar_i_close)(void);
 
-bool asar_init()
-{
 #define require(b) if (!(b)) { asardll=NULL; return false; }
-	if (asardll) return true;
-	asardll=getlib();
-	require(asardll);
-	//void * tmp;
 #define loadi(name) loadraw("asar_"#name, asar_i_##name)
 #define load(name) loadraw("asar_"#name, asar_##name)
+
+static bool asar_init_shared(void)
+{
 	loadi(init);
 	loadi(close);
 	load(version);
 	load(apiversion);
 	load(reset);
 	load(patch);
+	load(patch_ex);
 	load(maxromsize);
 	load(geterrors);
 	load(getwarnings);
@@ -59,12 +141,33 @@ bool asar_init()
 	load(getdefine);
 	load(getalldefines);
 	load(math);
-	if (asar_apiversion()<expectedapiversion || (asar_apiversion()/100)>(expectedapiversion/100)) return false;
+	load(getwrittenblocks);
+	load(getmapper);
+	load(getsymbolsfile);
+	if (asar_apiversion() < expectedapiversion || (asar_apiversion() / 100) > (expectedapiversion / 100)) return false;
 	require(asar_i_init());
 	return true;
 }
 
-void asar_close()
+bool asar_init(void)
+{
+	if (asardll) return true;
+	asardll=getlib();
+	require(asardll);
+	if (!asar_init_shared()) return false;
+	return true;
+}
+
+bool asar_init_with_dll_path(const char * dllpath)
+{
+	if (asardll) return true;
+	asardll = getlibfrompath(dllpath);
+	require(asardll);
+	if (!asar_init_shared()) return false;
+	return true;
+}
+
+void asar_close(void)
 {
 	if (!asardll) return;
 	asar_i_close();

--- a/src/AddmusicK/asardll.h
+++ b/src/AddmusicK/asardll.h
@@ -1,11 +1,19 @@
-#pragma once
+#ifndef ASAR_DLL_H_INCLUDED
+#	define ASAR_DLL_H_INCLUDED
+
+
+// RPG Hacker: Holy poopy; this is hacky.
+// All just for the convenience of not having to copy-paste
+// function prototypes into asardll.c, all while keeping
+// everything warning-free in clang...
 #ifndef asarfunc
+
 #define asarfunc extern
-#endif
 
-#define expectedapiversion 200
+#define expectedapiversion 303
 
-//#include <stdbool.h>
+#include <stdbool.h>
+#include <stddef.h> // for size_t
 
 //These structures are returned from various functions.
 struct errordata {
@@ -16,6 +24,7 @@ struct errordata {
 	int line;
 	const char * callerfilename;
 	int callerline;
+	int errid;
 };
 
 struct labeldata {
@@ -28,9 +37,93 @@ struct definedata {
 	const char * contents;
 };
 
+struct writtenblockdata {
+	int pcoffset;
+	int snesoffset;
+	int numbytes;
+};
+
+enum mappertype {
+	invalid_mapper,
+	lorom,
+	hirom,
+	sa1rom,
+	bigsa1rom,
+	sfxrom,
+	exlorom,
+	exhirom,
+	norom
+};
+
+struct warnsetting {
+	const char * warnid;
+	bool enabled;
+};
+
+struct memoryfile {
+	const char* path;
+	const void* buffer;
+	size_t length;
+};
+
+struct patchparams
+{
+	// The size of this struct. Set to (int)sizeof(patchparams).
+	int structsize;
+
+	// Same parameters as asar_patch()
+	const char * patchloc;
+	char * romdata;
+	int buflen;
+	int * romlen;
+
+	// Include paths to use when searching files.
+	const char** includepaths;
+	int numincludepaths;
+
+	// should everything be reset before patching? Setting it to false will make asar
+	// act like the currently patched file was directly appended to the previous one.
+	// note that you can't use the previous run's defines - you can use getalldefines()
+	// and additional_defines for that.
+	bool should_reset;
+
+	// A list of additional defines to make available to the patch.
+	const struct definedata * additional_defines;
+	int additional_define_count;
+
+	// Path to a text file to parse standard include search paths from.
+	// Set to NULL to not use any standard includes search paths.
+	const char* stdincludesfile;
+
+	// Path to a text file to parse standard defines from.
+	// Set to NULL to not use any standard defines.
+	const char* stddefinesfile;
+
+	// A list of warnings to enable or disable.
+	// Specify warnings in the format "WXXXX" where XXXX = warning ID.
+	const struct warnsetting * warning_settings;
+	int warning_setting_count;
+
+	// List of memory files to create on the virtual filesystem.
+	const struct memoryfile * memory_files;
+	int memory_file_count;
+
+	// Set override_checksum_gen to true and generate_checksum to true/false
+	// to force generating/not generating a checksum.
+	bool override_checksum_gen;
+	bool generate_checksum;
+};
+
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //Returns the version, in the format major*10000+minor*100+bugfix*1. This means that 1.2.34 would be
 // returned as 10234.
-asarfunc int (*asar_version)();
+asarfunc int (*asar_version)(void);
 
 //Returns the API version, format major*100+minor. Minor is incremented on backwards compatible
 // changes; major is incremented on incompatible changes. Does not have any correlation with the
@@ -38,16 +131,21 @@ asarfunc int (*asar_version)();
 //It's not very useful directly, since asar_init() verifies this automatically.
 //Calling this one also sets a flag that makes asar_init not instantly return false; this is so
 // programs expecting an older API won't do anything unexpected.
-asarfunc int (*asar_apiversion)();
+asarfunc int (*asar_apiversion)(void);
 
 //Initializes Asar. Call this before doing anything.
 //If it returns false, something went wrong, and you may not use any other Asar functions. This is
 //either due to not finding the library, or not finding all expected functions in the library.
-bool asar_init();
+bool asar_init(void);
+
+// Same as above, but instead of automatically looking for and trying to load asar.dll, takes
+// a path to the Asar DLL and tries to load it.
+// The path is expected to be UTF-8-encoded, even on Windows.
+bool asar_init_with_dll_path(const char * dllpath);
 
 //Clears out all errors, warnings and printed statements, and clears the file cache. Not really
 // useful, since asar_patch() already does this.
-asarfunc bool (*asar_reset)();
+asarfunc bool (*asar_reset)(void);
 
 //Applies a patch. The first argument is a filename (so Asar knows where to look for incsrc'd
 // stuff); however, the ROM is in memory.
@@ -55,16 +153,19 @@ asarfunc bool (*asar_reset)();
 // be altered by this function; if this is undesirable, set romlen equal to buflen.
 //The return value is whether any errors appeared (false=errors, call asar_geterrors for details).
 // If there is an error, romdata and romlen will be left unchanged.
-asarfunc bool (*asar_patch)(const char * patchloc, char * romdata, int buflen, int * romlen);
+asarfunc bool(*asar_patch)(const char * patchloc, char * romdata, int buflen, int * romlen);
+
+// An extended version of asar_patch() with a future-proof parameter format.
+asarfunc bool(*asar_patch_ex)(const struct patchparams * params);
 
 //Returns the maximum possible size of the output ROM from asar_patch(). Giving this size to buflen
 // guarantees you will not get any buffer too small errors; however, it is safe to give smaller
 // buffers if you don't expect any ROMs larger than 4MB or something.
-asarfunc int (*asar_maxromsize)();
+asarfunc int (*asar_maxromsize)(void);
 
 //Frees all of Asar's structures and unloads the module. Only asar_init may be called after calling
 // this; anything else will lead to segfaults.
-void asar_close();
+void asar_close(void);
 
 //Get a list of all errors.
 //All pointers from these functions are valid only until the same function is called again, or until
@@ -99,3 +200,18 @@ asarfunc const char * (*asar_resolvedefines)(const char * data, bool learnnew);
 // see if it's successful (NULL) or if it failed (non-NULL, contains a descriptive string). It does
 // not affect asar_geterrors.
 asarfunc double (*asar_math)(const char * math, const char ** error);
+
+//Get a list of all the blocks written to the ROM by calls such as asar_patch().
+asarfunc const struct writtenblockdata * (*asar_getwrittenblocks)(int * count);
+
+//Get the mapper currently used by Asar
+asarfunc enum mappertype (*asar_getmapper)(void);
+
+// Generates the contents of a symbols file for in a specific format.
+asarfunc const char * (*asar_getsymbolsfile)(const char * format);
+
+#ifdef __cplusplus
+	}
+#endif
+
+#endif		// ASAR_DLL_H_INCLUDED


### PR DESCRIPTION
The bindings present in the current repo are ancient, so I updated them to 1.81.
Move asar_init call as first thing to do because it was done too late and asar was called already before the bool was actually initialized, basically rendering the whole thing useless. This makes it so the dynamic library is actually used if present.