### PR TITLE
Filter out all duplicate samples from compiled songs

### DIFF
--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -3070,6 +3070,16 @@ void Music::pointersFirstPass()
 			emptySampleIndex = getSample("EMPTY.brr", this);
 		}
 
+		for (i = 0; i < mySamples.size()-1; i++)
+		{
+			for (j = i+1; j < mySamples.size(); j++)
+			{
+			if ((mySamples[i] == mySamples[j]) && mySamples[i] != emptySampleIndex)
+				{
+					mySamples[j] = emptySampleIndex;
+				}
+			}
+		}
 
 		for (i = 0; i < mySamples.size(); i++)
 		if (usedSamples[i] == false && samples[mySamples[i]].important == false)


### PR DESCRIPTION
This commit replicates something that AddmusicK 1.0.8 did with regards to its sample filtering by simply marking duplicates as empty samples instead in the song. Notably, this is being done regardless of the important markers.

This commit mentions #396. It does not close it because a longer term fix for this kind of situation would instead use duplicate pointers, of which the empty BRR sample does not properly do with its loop point specifically. This is because at some point down the road the user may want to take advantage of duplicate pointers allocated to multiple SRCN IDs for whatever reason. This is also because this currently only affects the C++ side: the full fix would also get the SNES side involved.