### PR TITLE
Test that the bit being tested is actually used by hardcoded 1DFA SFX

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1727,6 +1727,7 @@ endif
 
 .checkAPU1SFX
 if !useSFXSequenceFor1DFASFX = !false
+	bbc!1DFASFXChannel	$10, .sfxAllocAllowed
 	;Check and see if APU1 SFX is playing there via detecting $1D.
 	;APU1 SFX is playing if APU0/APU3 SFX sequence data is not playing,
 	;but $1D has a voice bit set.


### PR DESCRIPTION
Somehow triggering two SFX instances in a row while a 1DFA SFX was running was causing the jump SFX to stop its pitch bend entirely. The cause is that the bit was not tested to make sure the channel in question was actually used by 1DFA SFX, so that is now added on.

This merge request closes #388.