### PR TITLE
Upgrade the maximum number of SFX instruments permitted 

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1220,19 +1220,24 @@ FetchPtrFromSFXDataAndRET:
 SetSFXInstrument:
 	mov	y, #$09			; \ 
 	mul	ya			; | Set up the instrument table for SFX
-	mov	x, a			; |
+	mov	$14, #SFXInstrumentTable ; |
+	mov	$15, #SFXInstrumentTable>>8 ; |
+	addw	ya, $14			; |
+	movw	$14, ya			; |
+	mov	y, #$00			; |
 	mov	a, $46			; | \
 	xcn	a			; | | Get the correct DSP register "base" into y.
 	lsr	a			; | |
-	mov	y, a			; | /
-	mov	$12, #$08		; / 9 bytes of instrument data.
+	mov	x, a			; / /
 -					; \
-	mov	a, SFXInstrumentTable+x	; |
-	call	DSPWrite		; | Loop that sets various DSP registers.
+	mov	a, ($14)+y		; |
+	mov	$f2, x			; | Loop that sets various DSP registers.
+	mov	$f3, a			; |
 	inc	x			; |
 	inc	y			; |
-	dbnz	$12, -    		; / 
-	mov	a, SFXInstrumentTable+x ; \
+	cmp	y, #$08			; | 9 bytes of instrument data.
+	bcc	-  	  		; / 
+	mov	a, ($14)+y		; \
 	mov	x, $46			; | Set pitch base multiplier.
 	mov	$0210+x, a		; /
 	mov	a, #$00			; \ Disable sub-tuning

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -208,6 +208,10 @@
 		</ul>
 	</li>
 	</ul>
+	<h2>Version 1.0.10 Alpha - 2023-10-12</h2>
+	<ul>
+	<li>"Upgraded the maximum number of SFX instruments available from 28 (due to an 8-bit index offset limitation) to 128." - KungFuFurby</li>
+	</ul>
 
 	<br><br>
 	


### PR DESCRIPTION
Using a 16-bit offset allows for up to 128 SFX instruments to run at once. The
only reason why more isn't permitted is because $80 and up are used for noise.

This merge request closes #80.