### PR TITLE
Fix a conflict where PLB and RTL opcodes were being used by other patches

### DIFF
--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -184,7 +184,6 @@ YoshiDrumHijack:
 NoYoshiDrum:
 		LDA #$03
 		STA $1DFA|!SA1Addr2
-		PLB
 		RTL
 		NOP : NOP : NOP
 		NOP : NOP : NOP
@@ -192,7 +191,8 @@ NoYoshiDrum:
 		NOP : NOP : NOP
 		NOP : NOP : NOP
 		NOP : NOP : NOP
-		;This hijack overwrites 23 of the 41 NOPs consistently written to the ROM. Thus, we don't need these NOPs anymore.
+		NOP
+		;This hijack overwrites 22 of the 41 NOPs consistently written to the ROM. Thus, we don't need these NOPs anymore.
 		;NOP : NOP : NOP
 		;NOP : NOP : NOP
 		;NOP : NOP : NOP
@@ -200,15 +200,18 @@ NoYoshiDrum:
 		;NOP : NOP : NOP
 		;NOP : NOP : NOP
 		;NOP : NOP : NOP
-		;NOP : NOP
+		;NOP
 	Skip:
 
 org $02A763
-		JML YoshiDrumHijack
+		JSL YoshiDrumHijack
+		BRA YoshiDrumHijackPLBRTL
 		NOP : NOP : NOP
 		NOP : NOP : NOP
-		NOP : NOP : NOP
-		NOP : NOP : NOP
+		NOP : NOP
+YoshiDrumHijackPLBRTL:
+		PLB
+		RTL
 
 org $0094A0				; Don't upload music bank 1
 	BRA Skip1Point25 : NOP

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -210,7 +210,11 @@
 	</ul>
 	<h2>Version 1.0.10 Alpha - 2023-10-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.9 yet. - KungFuFurby</li>
+	<li>Gameplay
+		<ul>
+		<li>"Fixed a bug where the Yoshi Drum Hijack were conflicting with other SNES-side patches that used the PLB and RTL opcodes in this area." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 
 	<br><br>


### PR DESCRIPTION
Turns out the Yoshi Drum hijack conflicted with patches that were using these two opcodes to return from a routine, and thus essentially crashing the game in the process. So these two opcodes are being restored to their original location for the patches' sake.

This merge request closes #408.