### PR TITLE
Upgrade song memory overflow errors

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -221,6 +221,7 @@
 	<li>SPC & ROM Compilation
 		<ul>
 		<li>"Fixed a regression where duplicate samples were being assigned EMPTY.brr whereas they are expecting to still be the same sample. Now they use duplicate pointers so that they can be referred to at either internal sample ID. This also means that pre-existing cases from the sample groups will no longer have duplicate sample data loaded, meaning less memory consumption." - KungFuFurby</li>
+		<li>"Upgraded song-related memory overflow errors by no longer rounding them to the nearest $100 bytes and also identifying whether or not the echo buffer or the sample data caused the overflow." - KungFuFurby</li>
 		</ul>
 	</li>
 	</ul>

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1326,6 +1326,14 @@ void fixMusicPointers()
 				}
 				musics[i].spaceInfo.importantSampleCount = importantSampleCount;
 
+				int endOfSongAndSampleDataPos = checkPos;
+				
+				if (checkPos > 0x10000)
+				{
+					std::cerr << musics[i].name << ": Sample data exceeded total space in ARAM by 0x" << hex4 << checkPos - 0x10000 << " bytes." << std::dec << std::endl;
+					quit(1);
+				}
+
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
 				//musics[i].spaceInfo.echoBufferStartPos = checkPos;
@@ -1349,7 +1357,7 @@ void fixMusicPointers()
 
 				if (checkPos > 0x10000)
 				{
-					std::cerr << musics[i].name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << checkPos - 0x10000 << " bytes." << std::dec << std::endl;
+					std::cerr << musics[i].name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << endOfSongAndSampleDataPos - musics[i].spaceInfo.echoBufferStartPos << " bytes." << std::dec << std::endl;
 					quit(1);
 				}
 			}


### PR DESCRIPTION
The echo buffer overflow errors are no longer rounded to the nearest $100 bytes, and there is also a different error message for when the sample data causes the memory overflow before it ever reaches the part where the echo buffer is tested.

This merge request mentions #404. The only reason why it doesn't close it is because there is an edge case not covered here where the echo can overwrite $FF00-$FF03 if activated and the hot patch to disable echo writes is not activated. The memory location scenario is correctly detected, but additional work needs to be done to detect the usage of echo. If it is not used, then a hot patch should be generated to deal with this specific situation, then immediately execute the echo buffer allocation VCMD, then execute the intended hot patch settings.