### PR TITLE
Remove a PLB opcode that wasn't properly removed in the Yoshi Drums Hijack

### DIFF
--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -184,22 +184,10 @@ NoYoshiDrum:
 		LDA #$03
 		STA $1DFA|!SA1Addr2
 		RTL
-		NOP : NOP : NOP
-		NOP : NOP : NOP
-		NOP : NOP : NOP
-		NOP : NOP : NOP
-		NOP : NOP : NOP
-		NOP : NOP : NOP
-		NOP : NOP
-		;This hijack overwrites 20 of the 41 NOPs consistently written to the ROM. Thus, we don't need these NOPs anymore.
-		;NOP : NOP : NOP
-		;NOP : NOP : NOP
-		;NOP : NOP : NOP
-		;NOP : NOP : NOP
-		;NOP : NOP : NOP
-		;NOP : NOP : NOP
-		;NOP : NOP : NOP
-		;NOP
+		;Just write a bunch of NOPs up until we reach $0081AA.
+		;We automate this using a padding operation.
+padbyte $EA
+pad $0081AA
 	Skip:
 
 org $02A763

--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -179,7 +179,6 @@ YoshiDrumHijack:
 		LDA $1B9B|!SA1Addr2
 		BNE NoYoshiDrum
 		JSL $00FC7A|!Bank
-		PLB
 		RTL
 NoYoshiDrum:
 		LDA #$03
@@ -191,8 +190,8 @@ NoYoshiDrum:
 		NOP : NOP : NOP
 		NOP : NOP : NOP
 		NOP : NOP : NOP
-		NOP
-		;This hijack overwrites 22 of the 41 NOPs consistently written to the ROM. Thus, we don't need these NOPs anymore.
+		NOP : NOP
+		;This hijack overwrites 20 of the 41 NOPs consistently written to the ROM. Thus, we don't need these NOPs anymore.
 		;NOP : NOP : NOP
 		;NOP : NOP : NOP
 		;NOP : NOP : NOP


### PR DESCRIPTION
Reported and contributed by Mellonpizza, with me adapting the fix accordingly. Turns out my conflict fix forgot to remove one of the PLB opcodes, causing a stack fault.