### PR TITLE
Avoid enabling NMI during V-Blank after uploading

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -635,6 +635,12 @@ SkipSPCNormal:
 ;NoUpload:
 	STA !MusicReg
 	
+-:
+	LDA.w $4212
+	BPL -
+-:
+	LDA.w $4212
+	BMI -
 	LDA #$81
 	STA $4200
 	JMP End

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -232,7 +232,11 @@
 	</ul>
 	<h2>Version 1.0.11 Alpha - 2024-03-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.10 yet. - KungFuFurby</li>
+	<li>Gameplay
+		<ul>
+		<li>"Fixed a bug where enabling NMI during V-Blank would cause graphical interferences, such as messing up HDMA." - Yoshifanatic</li>
+		</ul>
+	</li>
 	</ul>
 
 	<br><br>


### PR DESCRIPTION
Contributed by Yoshifanatic. This prevents song uploading from re-enabling NMI
during V-Blank by ensuring that V-Blank was not only not active, but also not
about to occur. As a side effect of doing this, the upload time does increase by
a frame for safety reasons, but it also ensures that certain sensitive
operations set up during V-Blank, such as HDMA, don't get interfered with.

This commit closes https://github.com/KungFuFurby/AddMusicKFF/issues/426.