### PR TITLE
Reduce SFX lag by incorporating the same technique as the music

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -188,7 +188,10 @@ MainLoop:
 	clrc
 	adc   a, $44
 	mov   $44, a
-	bcc   L_0573
+	bcs   SFXTickOn
+	cmp   y, #$00
+	beq   L_0573
+SFXTickOn:
 	inc   $45
 if !noSFX = !false
 	call	ProcessSFX

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -232,7 +232,11 @@
 	</ul>
 	<h2>Version 1.0.11 Alpha - 2024-03-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.10 yet. - KungFuFurby</li>
+	<li>SPC700-Side ASM
+		<ul>
+		<li>"This version alleviates some of the slowdown in SFX and CPUIO register polling caused by higher tempos and/or frequent pitch bends in the music." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 
 	<br><br>


### PR DESCRIPTION
This is a known vanilla problem with the keyhole song, and like fine tune interference with the SFX, it eventually had to go. In this case, however, the reason was that the lag reduction exposed a different problem: namely, that if the CPU load was heavy enough on the music side, the SFX would also lag. Also as a side effect of this, it would also affect the polling rate of $1DF9, $1DFA and $1DFC commands, which is bad for sound driver responsiveness, especially as the acknowledgement part was taken out.

This commit closes #427.