### PR TITLE
Discard the hex output entirely and remove 0x marker for stat file tick counts

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -242,6 +242,11 @@
 		<li>"Fixed a bug where enabling NMI during V-Blank would cause graphical interferences, such as messing up HDMA." - Yoshifanatic</li>
 		</ul>
 	</li>
+	<li>Music MML Parser
+		<ul>
+		<li>"Removed the hex markers from the tick counters in the stats .txt file outputs for the music." - KungFuFurby</li>
+		</ul>
+	</li>
 	<li>SPC700-Side ASM
 		<ul>
 		<li>"This version alleviates some of the slowdown in SFX and CPUIO register polling caused by higher tempos and/or frequent pitch bends in the music." - KungFuFurby</li>

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -3305,14 +3305,14 @@ void Music::pointersFirstPass()
 		statStrStream << "FREE ARAM (APPROXIMATE):		0x" << hex4 << 0x10000 - (echoBufferSize << 11) - spaceUsedBySamples - totalSize - programUploadPos << "\n\n";
 	else
 		statStrStream << "FREE ARAM (APPROXIMATE):		UNKNOWN\n\n";
-	statStrStream << "CHANNEL 0 TICKS:			0x" << hex4 << channelLengths[0] << "\n";
-	statStrStream << "CHANNEL 1 TICKS:			0x" << hex4 << channelLengths[1] << "\n";
-	statStrStream << "CHANNEL 2 TICKS:			0x" << hex4 << channelLengths[2] << "\n";
-	statStrStream << "CHANNEL 3 TICKS:			0x" << hex4 << channelLengths[3] << "\n";
-	statStrStream << "CHANNEL 4 TICKS:			0x" << hex4 << channelLengths[4] << "\n";
-	statStrStream << "CHANNEL 5 TICKS:			0x" << hex4 << channelLengths[5] << "\n";
-	statStrStream << "CHANNEL 6 TICKS:			0x" << hex4 << channelLengths[6] << "\n";
-	statStrStream << "CHANNEL 7 TICKS:			0x" << hex4 << channelLengths[7] << "\n\n";
+	statStrStream << "CHANNEL 0 TICKS:			" << channelLengths[0] << "\n";
+	statStrStream << "CHANNEL 1 TICKS:			" << channelLengths[1] << "\n";
+	statStrStream << "CHANNEL 2 TICKS:			" << channelLengths[2] << "\n";
+	statStrStream << "CHANNEL 3 TICKS:			" << channelLengths[3] << "\n";
+	statStrStream << "CHANNEL 4 TICKS:			" << channelLengths[4] << "\n";
+	statStrStream << "CHANNEL 5 TICKS:			" << channelLengths[5] << "\n";
+	statStrStream << "CHANNEL 6 TICKS:			" << channelLengths[6] << "\n";
+	statStrStream << "CHANNEL 7 TICKS:			" << channelLengths[7] << "\n\n";
 	if (knowsLength)
 	{
 		statStrStream << "SONG INTRO LENGTH IN SECONDS:		" << std::dec << introSeconds << "\n";


### PR DESCRIPTION
As much as I would like to have this output hex, the main concern I have is either integer overflows in the long run if I choose to convert it to an int or some other shenanigans when trying to handle the conversion of a double for hex output. So instead, we'll just simply keep the decimal output, and instead get rid of the hex call and markers to prevent user confusion.

This merge request closes #321.