### PR TITLE
Swap BCS/BEQ opcodes when checking the starman timer for restoration

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -675,8 +675,8 @@ endif
 if !Starman != $00
 	LDA $1490|!SA1Addr2
 	CMP #$1E
-	BCS .starMusic
 	BEQ .restoreFromStarMusic
+	BCS .starMusic
 endif
 ++
 	RTS

--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -321,15 +321,19 @@ org $00A6ED
 	NOP : NOP : NOP
 Skip8:
 
-;org $00E2EB
-	;BRA Skip9 : NOP
-	;NOP : NOP
-org $00E2EE
-	BRA Skip9
+org $00E2EB
+	BRA Skip9 : NOP
+	NOP : NOP
 	NOP : NOP
 	NOP : NOP
 	NOP : NOP : NOP
-	;NOP
+	NOP
+	NOP : NOP : NOP
+	NOP : NOP : NOP
+	NOP : NOP : NOP
+	NOP : NOP
+	NOP : NOP
+	NOP : NOP : NOP
 Skip9:
 
 org $01C585	; 13 bytes

--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -29,21 +29,6 @@ org $00C9BD
 	db !IrisOut
 org $00D0DE
 	db !GameOver
-
-org $00E301
-if !PSwitchIsSFX == !true
-;;; Don't factor in the P-Switch and directional coin timers. Instead, only
-;;; use the star power timer. This is because the P-Switch music is now
-;;; a SFX instance playing with the actual level music.
-	BRA +
-	NOP #2
-+
-else
-	BEQ +
-	LDX.B #!PSwitch
-+
-endif
-
 org $00EEC3
 	db !StageClear
 org $00F60B

--- a/asm/SNES/tweaks.asm
+++ b/asm/SNES/tweaks.asm
@@ -307,18 +307,12 @@ org $00A6ED
 Skip8:
 
 org $00E2EB
-	BRA Skip9 : NOP
-	NOP : NOP
-	NOP : NOP
-	NOP : NOP
-	NOP : NOP : NOP
-	NOP
-	NOP : NOP : NOP
-	NOP : NOP : NOP
-	NOP : NOP : NOP
-	NOP : NOP
-	NOP : NOP
-	NOP : NOP : NOP
+	BRA Skip9
+		;Just write a bunch of NOPs up until we reach $00E308.
+		;We automate this using a padding operation.
+assert pc() <= $00E308
+padbyte $EA
+pad $00E308
 Skip9:
 
 org $01C585	; 13 bytes

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -240,6 +240,7 @@
 	<li>Gameplay
 		<ul>
 		<li>"Fixed a bug where enabling NMI during V-Blank would cause graphical interferences, such as messing up HDMA." - Yoshifanatic</li>
+		<li>"Fixed a bug where AddmusicK's code was not properly handing the expiration of the Starman timer due to a swapped BCS and BEQ opcode. <b>As part of the fix, the code snippet from $00E2EE has had its NOPed out area enlarged to start at $00E2EB and skip over all of the vanilla code for the storages that used the level music.</b>"</li>
 		</ul>
 	</li>
 	<li>SPC700-Side ASM


### PR DESCRIPTION
These two opcodes were checked in the wrong order, causing the BEQ case to never fire. As for why... the carry is set when greater than or equal to the previous value. This also retires a vanilla code snippet up to the point that it processes the sparkling effects.

This merge request closes #435.