### PR TITLE
don't prepend ./ to the asar command if the asar executable isn't in pwd

### DIFF
--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -143,16 +143,13 @@ void quit(int code)
 	exit(code);
 }
 
-int execute(const File &command, bool prepend)
+int execute(const File &command)
 {
-     std::string tempstr = command.cStr();
-     if (prepend)
-     {
+	std::string tempstr = command.cStr();
 #ifndef _WIN32
-	  tempstr.insert(0, "./");
+	if (fileExists("./asar")) tempstr.insert(0, "./");
 #endif
-     }
-     return system(tempstr.c_str());
+	return system(tempstr.c_str());
 }
 
 int scanInt(const std::string &str, const std::string &value)		// Scans an integer value that comes after the specified string within another string.  Must be in $XXXX format (or $XXXXXX, etc.).

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -123,7 +123,7 @@ void writeFile(const File &fileName, const std::vector<T> &vector)
 }
 
 void writeTextFile(const File &fileName, const std::string &string);
-int execute(const File &command, bool prepentDotSlash = true);
+int execute(const File &command);
 
 void printError(const std::string &error, bool isFatal, const std::string &fileName = "", int line = -1);
 void printWarning(const std::string &error, const std::string &fileName = "", int line = -1);


### PR DESCRIPTION
I have `asar` installed and available on `$PATH` - I think it's reasonable to look for the program on `$PATH` if it's not available in the current working directory.