### PR TITLE
Check $2141 for a zeroed value instead of using hardcoded NOPs

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -428,7 +428,12 @@ endif
 	
 	LDA !NoUploadSamples
 	BEQ +
-	NOP #3			; Missing waiting cycles after UploadSPCData added
+	;$2141 is still outputting a $BB, courtesy of acknowledging that it
+	;is ready for a data transfer. This is zeroed out upon the
+	;completion of the transfer, so wait for that to happen first.
+-:
+	LDA $2141
+	BNE -
 	JMP SPCNormal
 +
 	
@@ -602,8 +607,12 @@ NoMoreSamples:
 	STA $03				; |
 	JSL UploadSPCDataDynamic	; /
 	SEP #$20
-	NOP #11				; Needed to waste time. 10817b
-					; On ZSNES it works with only 4 NOPs because...ZSNES.
+	;$2141 is still outputting a $BB, courtesy of acknowledging that it
+	;is ready for a data transfer. This is zeroed out upon the
+	;completion of the transfer, so wait for that to happen first.
+-:
+	LDA $2141
+	BNE -
 	JMP SkipSPCNormal
 	
 					; Time to get the SPC out of its loop.
@@ -622,9 +631,14 @@ else					; |
 endif					; |
 	STA $02				; | 
 	JSL UploadSPCData		; /
-	
-	NOP #8				; Needed to waste time.
-					; On ZSNES it works with only 4 NOPs because...ZSNES.
+
+	;$2141 is still outputting a $BB, courtesy of acknowledging that it
+	;is ready for a data transfer. This is zeroed out upon the
+	;completion of the transfer, so wait for that to happen first.
+-:
+	LDA $2141
+	BNE -
+
 SPCNormal:				
 	SEP #$30
 	

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -260,7 +260,11 @@
 	</ul>
 	<h2>Version 1.0.12 Alpha - 2024-09-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.11 yet. - KungFuFurby</li>
+	<li>Gameplay
+		<ul>
+		<li>"Fixed a bug where a local song would sometimes initially fail to play after loading in some emulators." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
This should reduce emulator and hardware shenanigans caused by the very first command accidentally not making it to the SPC side to be played.

This commit closes #445.