### PR TITLE
Introduce a new song group ID to track the most recent local song loaded

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -40,6 +40,7 @@ endif
 !FreeRAM		= $7FB000
 !CurrentSong		= !FreeRAM+$00
 !NoUploadSamples	= !FreeRAM+$01
+!CurrentSongGroup	= !FreeRAM+$02
 !SongPositionLow	= !FreeRAM+$04
 !SongPositionHigh	= !FreeRAM+$05
 !SPCOutput1		= !SongPositionLow
@@ -313,8 +314,11 @@ endif
 	LDA !MusicMir			; |
 	CMP !MusicBackup		; |
 	BNE ++				; |
+	CMP !CurrentSongGroup		; |
+	BNE ++				; |
 	STA !CurrentSong		; |
 	STA !MusicBackup		; |
+	STA !CurrentSongGroup		; |
 	JMP SPCNormal			; |
 ++					; /
 	LDA !MusicMir
@@ -373,7 +377,7 @@ endif
 ;	JMP Fade
 ;+
 
-
+	STA !CurrentSongGroup
 	
 
 	LDA #$FF		; Send this as early as possible

--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -682,6 +682,7 @@ if !Starman != $00
 	BCS .starMusic
 	BEQ .restoreFromStarMusic
 endif
+if !TimerResetOnLevelFade == !true
 ++
 	RTS
 	
@@ -690,6 +691,10 @@ endif
 	STZ $14AE|!SA1Addr2
 	STZ $190C|!SA1Addr2
 	STZ $1490|!SA1Addr2
+else
+++
++
+endif
 	RTS
 	
 if !PSwitch != $00

--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -652,9 +652,11 @@ SkipSPCNormal:
 	JMP End
 	
 HandleSpecialSongs:
+if !TimerResetOnLevelFade == !true
 	LDA $0100|!SA1Addr2
 	CMP #$0F
 	BEQ +
+endif
 	LDA !MusicMir
 	CMP #!Miss
 	BEQ +
@@ -682,7 +684,6 @@ if !Starman != $00
 	BCS .starMusic
 	BEQ .restoreFromStarMusic
 endif
-if !TimerResetOnLevelFade == !true
 ++
 	RTS
 	
@@ -691,10 +692,6 @@ if !TimerResetOnLevelFade == !true
 	STZ $14AE|!SA1Addr2
 	STZ $190C|!SA1Addr2
 	STZ $1490|!SA1Addr2
-else
-++
-+
-endif
 	RTS
 	
 if !PSwitch != $00

--- a/asm/UserDefines.asm
+++ b/asm/UserDefines.asm
@@ -251,6 +251,18 @@ includeonce
 ;=======================================
 
 ;=======================================
+;---------------
+!TimerResetOnLevelFade = !true
+
+;Default setting: !true
+;---------------
+; If you set this to true, the P-Switch, star and directional coin timers
+; will be reset when transitioning to another room.
+; If you are using a patch that tries to make the timers persist between
+; rooms that works without AddmusicK, set this to false.
+;=======================================
+
+;=======================================
 ; If you've changed list.txt and plan on using the original SMW songs
 ; change these constants to whatever they are in list.txt
 ; For example, if you changed the "Stage Clear" music to be number 9,

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -263,6 +263,7 @@
 	<li>Gameplay
 	<ul>
 		<li>"Fixed a bug where changing level music while the Starman or P-Switch songs were active would cause the next level music to fail to load upon the conclusion of the Starman and/or the P-Switch effect." - KungFuFurby</li>
+		<li>"Added a new user define, !TimerResetOnLevelFade . This define is designed to allow patches that allow P-Switch, star and directional coin timers to persist between rooms that would otherwise fail when AddmusicK is applied on top of these patches." - KungFuFurby</li>
 	</ul>
 	</li>
 	</ul>

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -260,7 +260,11 @@
 	</ul>
 	<h2>Version 1.0.12 Alpha - 2024-09-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.11 yet. - KungFuFurby</li>
+	<li>Gameplay
+	<ul>
+		<li>"Fixed a bug where changing level music while the Starman or P-Switch songs were active would cause the next level music to fail to load upon the conclusion of the Starman and/or the P-Switch effect." - KungFuFurby</li>
+	</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
There is a situation where the level music can change during a Starman or P-Switch effect, and then the music can fail to switch over to the new local song upon the effect expiring. Since song groups are coming out in the future and this is one of the cases where it is critical that the correct song group is loaded, the variable is named to reflect its upcoming purpose.

This commit closes #444.