### PR TITLE
Correct pitch bend length for Bowser Defeated

### DIFF
--- a/music/originals/33 Bowser Defeated.txt
+++ b/music/originals/33 Bowser Defeated.txt
@@ -199,7 +199,7 @@ r16.
 q7fo2f8VCMD_SLIDETONOTE$00$0C>dVCMD_SLIDETONOTE$00$0C<e
 q7fo2a8VCMD_SLIDETONOTE$00$0C>fVCMD_SLIDETONOTE$00$0C<g
 q7fo3c8VCMD_SLIDETONOTE$00$0CgVCMD_SLIDETONOTE$00$0C<b
-q7eo3f8VCMD_SLIDETONOTE$00$0Cb;VCMD_SLIDETONOTE$00$0Cd
+q7eo3f8VCMD_SLIDETONOTE$00$18b;VCMD_SLIDETONOTE$00$18d
 ;Interrupted a dotted 16th of a note prior to completing the phrase.
 ;The second pitch slide of the last note is commented out because the
 ;interruption causes the command to fail to execute.

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -260,7 +260,11 @@
 	</ul>
 	<h2>Version 1.0.12 Alpha - 2024-09-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.11 yet. - KungFuFurby</li>
+	<li>Built-In Original Songs
+		<ul>
+		<li>"Fixed a bug where the Bowser Defeated song was using an incorrect pitch bend length for one of its notes." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
The wrong pitch bend length was defined when it was copied over from the original song data for channel 3. There is a second bug that is not replicated here: the pitch bend is paused for one tick due to a phrase end marker.

This merge request mentions #455.