### PR TITLE
Fix a stack fault with okayStatus when processing if statements

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -260,7 +260,11 @@
 	</ul>
 	<h2>Version 1.0.12 Alpha - 2024-09-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.11 yet. - KungFuFurby</li>
+	<li>Music MML Parser
+		<ul>
+		<li>"Corrected a stack fault that was causing nested if statements to result in a segmentation fault during preprocessing." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -787,7 +787,7 @@ void preprocess(std::string &str, const std::string &filename, int &version)
 
 			if (temp == "define")
 			{
-				if (!okayToAdd) { level++; continue; }
+				if (!okayToAdd) { level++; okayStatus.push(okayToAdd); continue; }
 
 				skipSpaces;
 				std::string temp2 = getArgument(str, ' ', i, filename, line, true);
@@ -814,7 +814,7 @@ void preprocess(std::string &str, const std::string &filename, int &version)
 			}
 			else if (temp == "undef")
 			{
-				if (!okayToAdd) { level++; continue; }
+				if (!okayToAdd) { level++; okayStatus.push(okayToAdd); continue; }
 
 				skipSpaces;
 				std::string temp2 = getArgument(str, ' ', i, filename, line, true);
@@ -824,7 +824,7 @@ void preprocess(std::string &str, const std::string &filename, int &version)
 			}
 			else if (temp == "ifdef")
 			{
-				if (!okayToAdd) { level++; continue; }
+				if (!okayToAdd) { level++; okayStatus.push(okayToAdd); continue; }
 
 				skipSpaces;
 				std::string temp2 = getArgument(str, ' ', i, filename, line, true);
@@ -842,7 +842,7 @@ void preprocess(std::string &str, const std::string &filename, int &version)
 			}
 			else if (temp == "ifndef")
 			{
-				if (!okayToAdd) { level++; continue; }
+				if (!okayToAdd) { level++; okayStatus.push(okayToAdd); continue; }
 
 				skipSpaces;
 				std::string temp2 = getArgument(str, ' ', i, filename, line, true);
@@ -860,7 +860,7 @@ void preprocess(std::string &str, const std::string &filename, int &version)
 			}
 			else if (temp == "if")
 			{
-				if (!okayToAdd) { level++; continue; }
+				if (!okayToAdd) { level++; okayStatus.push(okayToAdd); continue; }
 
 				skipSpaces;
 				std::string temp2 = getArgument(str, ' ', i, filename, line, true);


### PR DESCRIPTION
okayStatus, a stack boolean variable, was not being balanced properly because of a fault in skipping logic where it forgets to push to the stack when skipping the processing of if statements. This commit fixes that.

This pull request closes #463.