### PR TITLE
Handle SFX termination in the middle of a pitch bend

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -870,13 +870,23 @@ HandleSFXVoice:
 	setp
 	dec	!ChSFXNoteTimer&$FF+x
 	clrp
-	bne	.processSFXPitch
-
+	beq	+	
+	jmp	.processSFXPitch
++
 .getMoreSFXData
 	call	GetNextSFXByte		
-	bne	+			; If the current byte is zero, then end it.
+	bne	.notEnd			; If the current byte is zero, then end it.
+	mov	a, !PlayingVoices	; If the note was not keyed off, we'll have to do so manually.
+	and	a, $18
+	bne	+
 	jmp	EndSFX
 +
+	mov	a, #$00			; Stop the pitch bends immediately.
+	mov	$90+x, a
+	mov	$91+x, a
+	jmp	SFXTerminateCh
+.notEnd
+
 	bmi	.noteOrCommand		; If it's negative, then it's a command or note.
 	mov	!ChSFXNoteTimerBackup+x, a			
 					; The current byte is the duration.

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -260,7 +260,11 @@
 	</ul>
 	<h2>Version 1.0.12 Alpha - 2024-09-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.11 yet. - KungFuFurby</li>
+	<li>SFX
+		<ul>
+		<li>"Fixed a bug where terminating a SFX instance in the middle of a pitch bend with the $00 VCMD would cause the SFX instance to fail to key off, causing interference with the music."</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
If the voice has not been keyed off for whatever reason when the zero VCMD is
encountered to end the SFX instance, typically in the middle of a pitch bend,
then all pitch bends are stopped, then SFXTerminateCh is called to effectively
retrigger the command. SFXTerminateCh was actually not used at all if
!useSFXSequenceFor1DFASFX was !true because all of the calls and ways to access
it were filtered out. This also gives !PlayingVoices a purpose other than being
checked during vibrato processing.

This pull request closes #460.