### PR TITLE
Allow $DD VCMD to be called outside of readahead

### DIFF
--- a/asm/CommandTable.asm
+++ b/asm/CommandTable.asm
@@ -2,7 +2,7 @@ CommandDispatchTable:
 dw cmdDA
 dw cmdDB
 dw cmdDC
-dw $0000
+dw cmdDD
 dw cmdDE
 dw cmdDF
 dw cmdE0

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2714,6 +2714,19 @@ FetchVoiceXAndZeroA:
 ; vcmd F0: disable echo
 ; vcmd F1: set echo delay, feedback, filter
 
+cmdDD:					; Pitch bend
+	mov	$91+x, a				; \ Get the $DD parameters.
+	call	GetCommandDataFast			; |
+	mov	$90+x, a				; |
+	call	GetCommandDataFast			; /
+	clrc
+	adc	a, $43
+cmdDDAddHTuneValuesGate:
+	bra	cmdDDAddHTuneValuesSkip
+	clrc
+	adc	a, !HTuneValues+x
+cmdDDAddHTuneValuesSkip:
+
 ; calculate portamento delta
 CalcPortamentoDelta:
 	and	a, #$7f
@@ -3271,20 +3284,9 @@ L_10F3:
 	bra	L_1111
 endif
 L_10FB:
-	call	L_1260					; \ 
-	call	GetCommandDataFast			; |
-	mov	$91+x, a				; | Get the $DD parameters.
-	call	GetCommandDataFast			; |
-	mov	$90+x, a				; |
-	call	GetCommandDataFast			; /
-	clrc
-	adc	a, $43
-cmdDDAddHTuneValuesGate:
-	bra	cmdDDAddHTuneValuesSkip
-	clrc
-	adc	a, !HTuneValues+x
-cmdDDAddHTuneValuesSkip:
-	call	CalcPortamentoDelta
+	call	L_1260
+	call	GetCommandDataFast
+	call	cmdDD
 L_1111:
 	call	L_09CDWPreCheck
 L_1133:

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2714,7 +2714,29 @@ FetchVoiceXAndZeroA:
 ; vcmd F0: disable echo
 ; vcmd F1: set echo delay, feedback, filter
 
+cmdDDFromReadahead:
+	call	L_1260
+if !noSFX == !false
+	mov	a, $48					; \ 
+	and	a, $1d					; | Check to see if the current channel is disabled with a sound effect.
+	beq	L_10FB					; /
+	call	L_1260
+-
+	call	L_1260
+	jmp	L_1260
+endif
+
+L_10FB:
+	call	GetCommandDataFast
+
 cmdDD:					; Pitch bend
+if !noSFX == !false
+	push	a
+	mov	a, $48					; \ 
+	and	a, $1d					; | Check to see if the current channel is disabled with a sound effect.
+	pop	a					; |
+	bne	-					; /
+endif
 	mov	$91+x, a				; \ Get the $DD parameters.
 	call	GetCommandDataFast			; |
 	mov	$90+x, a				; |
@@ -3273,20 +3295,7 @@ L_10E4:
 	call	L_112A
 	bra	L_1133
 +
-if !noSFX == !false
-	mov	a, $48					; \ 
-	and	a, $1d					; | Check to see if the current channel is disabled with a sound effect.
-	beq	L_10FB					; /
-	mov	$10, #$04
-L_10F3:
-	call	L_1260
-	dbnz	$10, L_10F3
-	bra	L_1111
-endif
-L_10FB:
-	call	L_1260
-	call	GetCommandDataFast
-	call	cmdDD
+	call	cmdDDFromReadahead
 L_1111:
 	call	L_09CDWPreCheck
 L_1133:

--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2716,28 +2716,19 @@ FetchVoiceXAndZeroA:
 
 cmdDDFromReadahead:
 	call	L_1260
-if !noSFX == !false
-	mov	a, $48					; \ 
-	and	a, $1d					; | Check to see if the current channel is disabled with a sound effect.
-	beq	L_10FB					; /
-	call	L_1260
--
-	call	L_1260
-	jmp	L_1260
-endif
-
-L_10FB:
 	call	GetCommandDataFast
 
 cmdDD:					; Pitch bend
 if !noSFX == !false
-	push	a
 	mov	a, $48					; \ 
 	and	a, $1d					; | Check to see if the current channel is disabled with a sound effect.
-	pop	a					; |
-	bne	-					; /
+	beq	L_10FB					; /
+-
+	call	L_1260
+	jmp	L_1260
 endif
-	mov	$91+x, a				; \ Get the $DD parameters.
+L_10FB:
+	mov	$91+x, y				; \ Get the $DD parameters.
 	call	GetCommandDataFast			; |
 	mov	$90+x, a				; |
 	call	GetCommandDataFast			; /

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -260,7 +260,11 @@
 	</ul>
 	<h2>Version 1.0.12 Alpha - 2024-09-12</h2>
 	<ul>
-	<li>Oops! You're a little early. This version hasn't had any changes from 1.0.11 yet. - KungFuFurby</li>
+	<li>SPC700-Side ASM
+		<ul>
+		<li>"Fixed a bug where encountering the $DD command outside of readahead would crash the sound driver due to a zero pointer." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
Took a page out of standard N-SPC and implemented a way to call $DD without crashing things via zero pointer. I also managed to rig it so that it also costs no bytes via removing a call to CalcPortamentoDelta and instead go directly to the routine with no branching required.

We may need to check and make sure this doesn't result in SFX interference down the road, though.

This pull request closes #104.