### PR TITLE
jmp to SetFLGFromNCKValue after pausing the music when !noSFX is !true

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -1967,9 +1967,13 @@ PauseMusic:
 	mov !PauseMusic, a
 	
 	set1  !NCKValue.6	; Set the mute flag.
+if !noSFX == !false
 	;ModifyNoise, called when restoring the noise frequency, will handle
 	;setting the FLG DSP register.
 	ret
+else
+	jmp SetFLGFromNCKValue
+endif
 
 if !noSFX == !false && !useSFXSequenceFor1DFASFX == !false
 ;

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -275,6 +275,11 @@
 		<li>"Corrected a stack fault that was causing nested if statements to result in a segmentation fault during preprocessing." - KungFuFurby</li>
 		</ul>
 	</li>
+	<li>SPC700-Side ASM
+		<ul>
+		<li>"Fixed a bug where pausing with !noSFX set to !true was causing a note sticking effect instead of the intended muting effect." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
The noise frequency conflict restoration code does not exist when SFX is disabled, so we need to actually do the job of updating the FLG DSP register to prevent a note sticking effect.

This merge request closes #479.