### PR TITLE
Set carry prior to adjusting tempo by $0387

### DIFF
--- a/asm/Commands.asm
+++ b/asm/Commands.asm
@@ -317,6 +317,7 @@ SubC_7_storeTo387:
 cmdE2:					; Change the tempo
 {
 L_0E14: 
+	setc
 	adc   a, $0387			; WARNING: This is sometimes called to change the tempo.  Changing this function is NOT recommended!
 	mov   $51, a
 	mov   $50, #$00

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -275,6 +275,11 @@
 		<li>"Corrected a stack fault that was causing nested if statements to result in a segmentation fault during preprocessing." - KungFuFurby</li>
 		</ul>
 	</li>
+	<li>SPC700-Side ASM
+		<ul>
+		<li>"Fixed a bug where the Hurry Up! SFX had inconsistent off-by-one errors on the amount it was adding on to the tempo (sometimes it was adding $0A, and sometimes it was adding $0B). It now replicates the same behavior as when a hex command is called to change the tempo, meaning it adds the intended value plus one (with the one being a vanilla SMW bug that caused all of the off-by-one errors)." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
This behavior replicates vanilla SMW's behavior when calling a hex command to set the tempo and ensures that tempo adjustments are consistent.

This merge request closes #480.