### PR TITLE
Deduplicate sample group pointers for songs

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -280,6 +280,11 @@
 		<li>"Corrected a stack fault that was causing nested if statements to result in a segmentation fault during preprocessing." - KungFuFurby</li>
 		</ul>
 	</li>
+	<li>SPC & ROM Compilation
+		<ul>
+		<li>"All sample group pointers are now deduplicated prior to being compiled for a ROM." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1102,10 +1102,16 @@ void compileMusic()
 	}
 
 	songSampleList << "\n\n";
+	
+	bool musicInSampleList[256];
+	for (int i = 0; i < sizeof(musicInSampleList); i++)
+	{
+		musicInSampleList[i] = false;
+	}
 
 	for (int i = 0; i < songCount; i++)
 	{
-		if (!musics[i].exists) continue;
+		if ((!musics[i].exists) || (musicInSampleList[i])) continue;
 
 		songSampleListSize++;
 
@@ -1113,6 +1119,22 @@ void compileMusic()
 
 		if (i > highestGlobalSong)
 		{
+			for (int j = highestGlobalSong+1; j < songCount; j++) {
+				if (i == j) continue;
+				if (!musics[j].exists) continue;
+				if (musics[i].mySamples.size() != musics[j].mySamples.size()) continue;
+				bool sampleGroupMatch = true;
+				for (unsigned int k = 0; k < musics[i].mySamples.size(); k++)
+				{
+					if ((musics[i].mySamples[k]) != (musics[j].mySamples[k])){
+						sampleGroupMatch = false;
+					}
+				}
+				if (sampleGroupMatch) {
+					songSampleList << "\n" << "SGPointer" << hex2 << j << ":\n";
+					musicInSampleList[j] = true;
+				}
+			}
 			songSampleList << "db $" << hex2 << musics[i].mySamples.size() << "\ndw";
 			for (unsigned int j = 0; j < musics[i].mySamples.size(); j++)
 			{


### PR DESCRIPTION
Recycling sample group pointers will help reduce the amount of space consumed in the ROM. It'll also help streamline things in the long run if we were to do lag reduction on loading new songs, as the simplest form of this involves simply keeping the sample directory pointer consistent and checking for a duplicate sample group pointer... although even this would require a data version bump.

This merge request closes #424.