### PR TITLE
Relocate the SFX/Yoshi Drum check in arpeggio code

### DIFF
--- a/asm/main.asm
+++ b/asm/main.asm
@@ -2410,8 +2410,6 @@ HandleArpeggioInterrupt:
 .anythingGoes
 	mov	!PreviousNote+x, a	; Save the current note pitch.  The arpeggio command needs it.
 +
-	mov	a, $10
-	bne	L_0CB3
 	cmp	y, #$c6			; \ Ties and rests shouldn't affect anything arpeggio related.
 	bcs	+			; /
 	mov	a, !ArpNoteCount+x	; \ If there's currently an arpeggio playing (which handles its own notes)...
@@ -2432,6 +2430,8 @@ HandleArpeggioInterrupt:
 	mov	!ArpCurrentDelta+x, a	; | If we're turning it off, then reset the delta.
 +
 .glissandoOver
+	mov	a, $10
+	bne	L_0CB3
 	mov	a, y			; / And actually play the next note.
 	call	NoteVCMD             ; handle note cmd if vbit 1D clear
 .glissandoIsStillOn

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -285,6 +285,11 @@
 		<li>"All sample group pointers are now deduplicated prior to being compiled for a ROM." - KungFuFurby</li>
 		</ul>
 	</li>
+	<li>SPC700-Side ASM
+		<ul>
+		<li>"Fixed a bug where glissando was failing to do its first semitone addition with the hot patch disabled when SFX was played on top of the first note." - KungFuFurby</li>
+		</ul>
+	</li>
 	</ul>
 	<br><br>
 	


### PR DESCRIPTION
The arpeggio stuff should still be updated to handle the notes. Without doing this, glissando in particular will fail to perform its first semitone offset operation, and other parts of the arpeggio may operate incorrectly.

This merge request closes #506.