### PR TITLE
Compile SFX ASM at the exact location it is going to be inserted at

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -283,6 +283,7 @@
 	<li>SPC & ROM Compilation
 		<ul>
 		<li>"All sample group pointers are now deduplicated prior to being compiled for a ROM." - KungFuFurby</li>
+		<li>"Fixed a bug where SFX ASM were generating incorrect pointers within the ASM. - KungFuFurby"</li>
 		</ul>
 	</li>
 	<li>SPC700-Side ASM

--- a/src/AddmusicK/SoundEffect.cpp
+++ b/src/AddmusicK/SoundEffect.cpp
@@ -485,7 +485,7 @@ void SoundEffect::compileASM()
 		std::stringstream asmCode;
 		removeFile("temp.bin");
 		removeFile("temp.asm");
-		asmCode << "norom\narch spc700\n\norg $000000\nincsrc \"" << "asm/main.asm" << "\"\nbase $" << hex4 << posInARAM + code.size() + data.size() << "\n\norg $008000\n\n" << asmStrings[i];
+		asmCode << "norom\narch spc700\n\norg $000000\nincsrc \"" << "asm/main.asm" << "\"\n\norg $" << hex4 << posInARAM + code.size() + data.size() << "\n\n" << asmStrings[i];
 		writeTextFile("temp.asm", asmCode.str());
 
 		if (!asarCompileToBIN("temp.asm", "temp.bin"))
@@ -495,7 +495,7 @@ void SoundEffect::compileASM()
 
 		openFile("temp.bin", temp);
 
-		temp.erase(temp.begin(), temp.begin() + 0x08000);
+		temp.erase(temp.begin(), temp.begin() + posInARAM + code.size() + data.size());
 
 		for (unsigned int j = 0; j < temp.size(); j++)
 			code.push_back(temp[j]);


### PR DESCRIPTION
The org directive was overwriting the memory location defined in base, causing ASM pointers to come out faulty. I ultimately determined that the base directive was not needed, and thus the code is now compiled at the exact location that was calculated using only an org statement. This allows all SFX ASM-generated labels to function properly.

This merge request closes #511.