### PR TITLE
Add memory remaining reports

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -285,6 +285,7 @@
 		<li>"All sample group pointers are now deduplicated prior to being compiled for a ROM." - KungFuFurby</li>
 		<li>"Fixed a bug where SFX ASM were generating incorrect pointers within the ASM. - KungFuFurby"</li>
 		<li>"Fixed a bug where a zero pointer was generated in SFX if #jsr was used, but no #asm sections were defined at all. - KungFuFurby"</li>
+		<li>"Added memory remaining statements to output and stats.txt files." - KungFuFurby</li>
 		</ul>
 	</li>
 	<li>SPC700-Side ASM

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1319,7 +1319,7 @@ void fixMusicPointers()
 				musics[i].spaceInfo.songEndPos = musics[i].spaceInfo.songStartPos + sizeWithPadding;
 
 				int checkPos = songDataARAMPos + sizeWithPadding;
-				printf("Music overhead remaining (to next DIR increment): 0x%X bytes\n", 0x100-(checkPos & 0xFF));
+				printf("Music overhead remaining (to next DIR increment): 0x%X bytes\n", (0x100 - (checkPos % 0x100));
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
 				musics[i].spaceInfo.sampleTableStartPos = checkPos;

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1062,6 +1062,19 @@ void compileMusic()
 			if (i > highestGlobalSong) {
 				musics[i].echoBufferSize = std::max(musics[i].echoBufferSize, maxGlobalEchoBufferSize);
 			}
+			std::string fname = musics[i].name;
+		
+			int extPos = fname.find_last_of('.');
+			if (extPos != -1)
+				fname = fname.substr(0, extPos);
+		
+			if (fname.find('/') != -1)
+				fname = fname.substr(fname.find_last_of('/') + 1);
+			else if (fname.find('\\') != -1)
+				fname = fname.substr(fname.find_last_of('\\') + 1);
+			fname = "stats/" + fname + ".txt";
+			musics[i].statFName = fname;
+			
 			musics[i].compile();
 			if (i <= highestGlobalSong) {
 				maxGlobalEchoBufferSize = std::max(musics[i].echoBufferSize, maxGlobalEchoBufferSize);
@@ -1317,6 +1330,8 @@ void fixMusicPointers()
 		{
 			if (checkEcho)
 			{
+				std::stringstream statStrStream;
+				statStrStream << "\n" << "LOCAL SONG MEMORY REMAINING STATS..." << "\n";
 				if (justSPCsPlease || verbose)
 					printf("%s\n", musics[i].name.c_str());
 				musics[i].spaceInfo.songStartPos = songDataARAMPos;
@@ -1324,8 +1339,10 @@ void fixMusicPointers()
 
 				int checkPos = songDataARAMPos + sizeWithPadding;
 				int songDataToSampleTableGap = checkPos % 0x100;
+				int songDataLeftBeforeSampleTableRealignment = (0x100 - songDataToSampleTableGap) % 0x100;
+				statStrStream << "SONG DATA LEFT BEFORE SAMPLE TABLE REALIGNMENT: 0X" << hex4 << songDataLeftBeforeSampleTableRealignment << "\n";
 				if (justSPCsPlease || verbose)
-					printf("Song data left before sample table realignment: 0x%X bytes\n", (0x100 - songDataToSampleTableGap) % 0x100);
+					printf("Song data left before sample table realignment: 0x%X bytes\n", songDataLeftBeforeSampleTableRealignment);
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
 				musics[i].spaceInfo.sampleTableStartPos = checkPos;
@@ -1364,10 +1381,14 @@ void fixMusicPointers()
 				
 				if (checkPos > 0x10000)
 				{
-					std::cerr << musics[i].name << ": Sample data exceeded total space in ARAM by 0x" << hex4 << checkPos - 0x10000 << " bytes." << std::dec << std::endl;
-					std::cerr << "Without modifying samples, song size must be reduced by at least 0x" << hex4 << (((checkPos - 0x10000)/0x100)*0x100) + songDataToSampleTableGap << " bytes." << std::dec << std::endl;
+					int overflowSize = checkPos - 0x10000;
+					std::cerr << musics[i].name << ": Sample data exceeded total space in ARAM by 0x" << hex4 << overflowSize << " bytes." << std::dec << std::endl;
+					std::cerr << "Without modifying samples, song size must be reduced by at least 0x" << hex4 << (((overflowSize)/0x100)*0x100) + songDataToSampleTableGap << " bytes." << std::dec << std::endl;
 					if (musics[i].echoBufferSize > 0)
 						std::cerr << "Echo must also be disabled as part of this process." << std::dec << std::endl;
+					statStrStream << "SAMPLE AND ECHO SPACE REMAINING: OVERFLOW BY 0X" << hex4 << overflowSize +  (musics[i].echoBufferSize << 11)<< "\n";
+					musics[i].statStr.append(statStrStream.str());
+					writeTextFile(musics[i].statFName, musics[i].statStr);
 					quit(1);
 				}
 
@@ -1396,9 +1417,12 @@ void fixMusicPointers()
 				{
 					std::cerr << musics[i].name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << endOfSongAndSampleDataPos - musics[i].spaceInfo.echoBufferStartPos << " bytes." << std::dec << std::endl;
 					std::cerr << "Without modifying samples or echo, song size must be reduced by at least 0x" << hex4 << (checkPos - 0x10100) + songDataToSampleTableGap << std::dec << std::endl << "bytes." << std::dec << std::endl;
+					statStrStream << "SAMPLE AND ECHO SPACE REMAINING: OVERFLOW BY 0X" << hex4 << endOfSongAndSampleDataPos - musics[i].spaceInfo.echoBufferStartPos << "\n";
+					musics[i].statStr.append(statStrStream.str());
+					writeTextFile(musics[i].statFName, musics[i].statStr);
 					quit(1);
 				}
-				else if (justSPCsPlease || verbose) {
+				else {
 					int sampleAndEchoSpaceRemaining;
 					if (musics[i].echoBufferSize > 0) {
 						sampleAndEchoSpaceRemaining = musics[i].spaceInfo.echoBufferStartPos-endOfSongAndSampleDataPos;
@@ -1406,7 +1430,12 @@ void fixMusicPointers()
 					else {
 						sampleAndEchoSpaceRemaining = 0x10000 - endOfSongAndSampleDataPos;
 					}
-					printf("Sample and echo space remaining: 0x%X bytes\n\n", sampleAndEchoSpaceRemaining);
+					statStrStream << "SAMPLE AND ECHO SPACE REMAINING: 0X" << hex4 << sampleAndEchoSpaceRemaining << "\n";
+					musics[i].statStr.append(statStrStream.str());
+					writeTextFile(musics[i].statFName, musics[i].statStr);
+					if (justSPCsPlease || verbose) {
+						printf("Sample and echo space remaining: 0x%X bytes\n\n", sampleAndEchoSpaceRemaining);
+					}
 				}
 			}
 		}

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1172,7 +1172,7 @@ void fixMusicPointers()
 
 	bool addedLocalPtr = false;
 	
-	if (checkEcho) {
+	if (checkEcho && (justSPCsPlease || verbose)) {
 		printf("\nMemory remaining...\n");
 	}
 

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1321,7 +1321,7 @@ void fixMusicPointers()
 
 				int checkPos = songDataARAMPos + sizeWithPadding;
 				if (justSPCsPlease || verbose)
-					printf("Music overhead remaining (to next DIR increment): 0x%X bytes\n", (0x100 - (checkPos % 0x100));
+					printf("Song data left before sample table realignment: 0x%X bytes\n", (0x100 - (checkPos % 0x100));
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
 				musics[i].spaceInfo.sampleTableStartPos = checkPos;

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1171,10 +1171,7 @@ void fixMusicPointers()
 	//int songPointerARAMPos = programSize + programPos;
 
 	bool addedLocalPtr = false;
-	
-	if (checkEcho && (justSPCsPlease || verbose)) {
-		printf("\nMemory remaining...\n");
-	}
+	bool memoryRemainingPrinted = false;
 
 	for (int i = 0; i < 256; i++)
 	{
@@ -1189,11 +1186,17 @@ void fixMusicPointers()
 			globalPointers << "\ndw song" << hex2 << i;
 			incbins << "song" << hex2 << i << ": incbin \"" << "SNES/bin/" << "music" << hex2 << i << ".bin\"\n";
 		}
-		else if (addedLocalPtr == false)
-		{
-			globalPointers << "\ndw localSong";
-			incbins << "localSong: ";
-			addedLocalPtr = true;
+		else {
+			if (checkEcho && (justSPCsPlease || verbose) && !memoryRemainingPrinted) {
+				printf("\nMemory remaining...\n");
+				memoryRemainingPrinted = true;
+			}
+			if (addedLocalPtr == false)
+			{
+				globalPointers << "\ndw localSong";
+				incbins << "localSong: ";
+				addedLocalPtr = true;
+			}
 		}
 
 		for (int j = 0; j < musics[i].spaceForPointersAndInstrs; j+=2)

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1366,6 +1366,8 @@ void fixMusicPointers()
 				{
 					std::cerr << musics[i].name << ": Sample data exceeded total space in ARAM by 0x" << hex4 << checkPos - 0x10000 << " bytes." << std::dec << std::endl;
 					std::cerr << "Without modifying samples, song size must be reduced by at least 0x" << hex4 << (((checkPos - 0x10000)/0x100)*0x100) + songDataToSampleTableGap << " bytes." << std::dec << std::endl;
+					if (musics[i].echoBufferSize > 0)
+						std::cerr << "Echo must also be disabled as part of this process." << std::dec << std::endl;
 					quit(1);
 				}
 

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1171,6 +1171,10 @@ void fixMusicPointers()
 	//int songPointerARAMPos = programSize + programPos;
 
 	bool addedLocalPtr = false;
+	
+	if (checkEcho) {
+		printf("\nMemory remaining...\n");
+	}
 
 	for (int i = 0; i < 256; i++)
 	{
@@ -1310,10 +1314,12 @@ void fixMusicPointers()
 		{
 			if (checkEcho)
 			{
+				printf("%s\n", musics[i].name.c_str());
 				musics[i].spaceInfo.songStartPos = songDataARAMPos;
 				musics[i].spaceInfo.songEndPos = musics[i].spaceInfo.songStartPos + sizeWithPadding;
 
 				int checkPos = songDataARAMPos + sizeWithPadding;
+				printf("Music overhead remaining (to next DIR increment): 0x%X bytes\n", 0x100-(checkPos & 0xFF));
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
 				musics[i].spaceInfo.sampleTableStartPos = checkPos;
@@ -1381,6 +1387,16 @@ void fixMusicPointers()
 				{
 					std::cerr << musics[i].name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << endOfSongAndSampleDataPos - musics[i].spaceInfo.echoBufferStartPos << " bytes." << std::dec << std::endl;
 					quit(1);
+				}
+				else {
+					int sampleAndEchoSpaceRemaining;
+					if (musics[i].echoBufferSize > 0) {
+						sampleAndEchoSpaceRemaining = musics[i].spaceInfo.echoBufferStartPos-endOfSongAndSampleDataPos;
+					}
+					else {
+						sampleAndEchoSpaceRemaining = 0x10000 - endOfSongAndSampleDataPos;
+					}
+					printf("Sample and echo space remaining: 0x%X bytes\n\n", sampleAndEchoSpaceRemaining);
 				}
 			}
 		}

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1320,8 +1320,9 @@ void fixMusicPointers()
 				musics[i].spaceInfo.songEndPos = musics[i].spaceInfo.songStartPos + sizeWithPadding;
 
 				int checkPos = songDataARAMPos + sizeWithPadding;
+				int songDataToSampleTableGap = checkPos % 0x100;
 				if (justSPCsPlease || verbose)
-					printf("Song data left before sample table realignment: 0x%X bytes\n", (0x100 - (checkPos % 0x100));
+					printf("Song data left before sample table realignment: 0x%X bytes\n", (0x100 - songDataToSampleTableGap) % 0x100);
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
 				musics[i].spaceInfo.sampleTableStartPos = checkPos;
@@ -1361,6 +1362,7 @@ void fixMusicPointers()
 				if (checkPos > 0x10000)
 				{
 					std::cerr << musics[i].name << ": Sample data exceeded total space in ARAM by 0x" << hex4 << checkPos - 0x10000 << " bytes." << std::dec << std::endl;
+					std::cerr << "Without modifying samples, song size must be reduced by at least 0x" << hex4 << (((checkPos - 0x10000)/0x100)*0x100) + songDataToSampleTableGap << " bytes." << std::dec << std::endl;
 					quit(1);
 				}
 
@@ -1388,6 +1390,7 @@ void fixMusicPointers()
 				if (checkPos > 0x10000)
 				{
 					std::cerr << musics[i].name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << endOfSongAndSampleDataPos - musics[i].spaceInfo.echoBufferStartPos << " bytes." << std::dec << std::endl;
+					std::cerr << "Without modifying samples or echo, song size must be reduced by at least 0x" << hex4 << (checkPos - 0x10100) + songDataToSampleTableGap << std::dec << std::endl << "bytes." << std::dec << std::endl;
 					quit(1);
 				}
 				else if (justSPCsPlease || verbose) {

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1314,12 +1314,14 @@ void fixMusicPointers()
 		{
 			if (checkEcho)
 			{
-				printf("%s\n", musics[i].name.c_str());
+				if (justSPCsPlease || verbose)
+					printf("%s\n", musics[i].name.c_str());
 				musics[i].spaceInfo.songStartPos = songDataARAMPos;
 				musics[i].spaceInfo.songEndPos = musics[i].spaceInfo.songStartPos + sizeWithPadding;
 
 				int checkPos = songDataARAMPos + sizeWithPadding;
-				printf("Music overhead remaining (to next DIR increment): 0x%X bytes\n", (0x100 - (checkPos % 0x100));
+				if (justSPCsPlease || verbose)
+					printf("Music overhead remaining (to next DIR increment): 0x%X bytes\n", (0x100 - (checkPos % 0x100));
 				if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;
 
 				musics[i].spaceInfo.sampleTableStartPos = checkPos;
@@ -1388,7 +1390,7 @@ void fixMusicPointers()
 					std::cerr << musics[i].name << ": Echo buffer exceeded total space in ARAM by 0x" << hex4 << endOfSongAndSampleDataPos - musics[i].spaceInfo.echoBufferStartPos << " bytes." << std::dec << std::endl;
 					quit(1);
 				}
-				else {
+				else if (justSPCsPlease || verbose) {
 					int sampleAndEchoSpaceRemaining;
 					if (musics[i].echoBufferSize > 0) {
 						sampleAndEchoSpaceRemaining = musics[i].spaceInfo.echoBufferStartPos-endOfSongAndSampleDataPos;

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -3328,19 +3328,7 @@ void Music::pointersFirstPass()
 
 	statStr = statStrStream.str();
 
-	std::string fname = name;
-
-	int extPos = fname.find_last_of('.');
-	if (extPos != -1)
-		fname = fname.substr(0, extPos);
-
-	if (fname.find('/') != -1)
-		fname = fname.substr(fname.find_last_of('/') + 1);
-	else if (fname.find('\\') != -1)
-		fname = fname.substr(fname.find_last_of('\\') + 1);
-	fname = "stats/" + fname + ".txt";
-
-	writeTextFile(fname, statStr);
+	writeTextFile(statFName, statStr);
 }
 
 void Music::parseDefine()

--- a/src/AddmusicK/Music.h
+++ b/src/AddmusicK/Music.h
@@ -36,6 +36,7 @@ public:
 
 	std::string name;
 	std::string pathlessSongName;
+	std::string statFName;
 	std::vector<uint8_t> data[9];
 	std::vector<unsigned short> loopLocations[9];	// With remote loops, we can have remote loops in standard loops, so we need that ninth channel.
 	bool playOnce;


### PR DESCRIPTION
This pull request mentions #518. It does not close it because of the zero EDL case: the zero EDL case will be taken care of elsewhere because it needs extra detection work first to determine whether the buffer's being used at all, and then the issue can be safely closed. This is handled through #522.

- [x] Output to the command line
- [x] Output to stats.txt