### PR TITLE
Filter out the upper nibble of the EDL parameter when determining buffer sizes

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -287,6 +287,7 @@
 		<li>"Fixed a bug where a zero pointer was generated in SFX if #jsr was used, but no #asm sections were defined at all." - KungFuFurby</li>
 		<li>"Fixed a bug where the echo buffer size to allocate was not factoring in the $F6 hex command when writing to the EDL DSP register." - KungFuFurby</li>
 		<li>"Added memory remaining statements to output and stats.txt files." - KungFuFurby</li>
+		<li>"The limitations of the EDL register are now factored in when calculating the echo buffer size to allocate: that is, they only go from $00-$0F." - KungFuFurby</li>
 		</ul>
 	</li>
 	<li>SPC700-Side ASM

--- a/src/AddmusicK/Music.cpp
+++ b/src/AddmusicK/Music.cpp
@@ -1527,6 +1527,7 @@ void Music::parseHFDHex()
 				songTargetProgram = 1;		// The HFD header bytes indicate this as being an AM4 song, so it gets AM4 treatment.
 				if (reg == 0x7D) {
 					// Set a base echo buffer allocation size based off of the EDL DSP register value that is used.
+					val &= 0xF;
 					echoBufferSize = std::max(echoBufferSize, val);
 				}
 			}
@@ -1981,12 +1982,14 @@ void Music::parseHexCommand()
 			{
 				if (currentDSPRegister == 0x7D)
 				{
+					i &= 0xF;
 					echoBufferSize = std::max(echoBufferSize, i);
 				}
 			}
 
 			if (hexLeft == 2 && currentHex == 0xF1)
 			{
+				i &= 0xF;
 				echoBufferSize = std::max(echoBufferSize, i);
 				hasEchoBufferCommand = true;
 			}


### PR DESCRIPTION
This covers the C++ side. The SPC side was indirectly accounted for, but not with the raw parameters: instead, it was handled on calculating the ESA and what needed to be cleared. The raw parameters should be handled with ANDing as well so that the comparisons don't redo the buffer allocations due to a mistake in the song data.

This commit mentions #363.