### PR TITLE
Transform the musics variable into a map

### DIFF
--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -260,6 +260,9 @@
 	</ul>
 	<h2>Version 1.0.12 Alpha - 2026-04-26</h2>
 	<ul>
+	<li>Overall
+		<li>"The way the music collection has been handled internally has been modified in terms of its data type: instead of using an array of 256 entries, they now use maps. This will help prevent future complaints from compilers due to too much memory being requested for allocation for an array of music instances." - KungFuFurby</li>
+	</li>
 	<li>Gameplay
 		<ul>
 		<li>"Fixed a bug where a local song would sometimes initially fail to play after loading in some emulators." - KungFuFurby</li>

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include "lodepng.h"
 #include <thread>
-
+#include <map>
 
 bool waitAtEnd = true;
 File ROMName;
@@ -568,10 +568,12 @@ void loadMusicList()
 
 	for (int i = 255; i >= 0; i--)
 	{
-		if (musics[i].exists)
-		{
-			songCount = i+1;
-			break;
+		if (musics.count(i)) {
+			if (musics[i].exists)
+			{
+				songCount = i+1;
+				break;
+			}
 		}
 	}
 }
@@ -1054,33 +1056,35 @@ void compileMusic()
 	int maxGlobalEchoBufferSize = 0;
 	for (int i = 0; i < 256; i++)
 	{
-		if (musics[i].exists)
-		{
-			//if (!(i <= highestGlobalSong && !recompileMain))
-			//{
-			musics[i].index = i;
-			if (i > highestGlobalSong) {
-				musics[i].echoBufferSize = std::max(musics[i].echoBufferSize, maxGlobalEchoBufferSize);
-			}
-			std::string fname = musics[i].name;
-		
-			int extPos = fname.find_last_of('.');
-			if (extPos != -1)
-				fname = fname.substr(0, extPos);
-		
-			if (fname.find('/') != -1)
-				fname = fname.substr(fname.find_last_of('/') + 1);
-			else if (fname.find('\\') != -1)
-				fname = fname.substr(fname.find_last_of('\\') + 1);
-			fname = "stats/" + fname + ".txt";
-			musics[i].statFName = fname;
+		if (musics.count(i)) {
+			if (musics[i].exists)
+			{
+				//if (!(i <= highestGlobalSong && !recompileMain))
+				//{
+				musics[i].index = i;
+				if (i > highestGlobalSong) {
+					musics[i].echoBufferSize = std::max(musics[i].echoBufferSize, maxGlobalEchoBufferSize);
+				}
+				std::string fname = musics[i].name;
 			
-			musics[i].compile();
-			if (i <= highestGlobalSong) {
-				maxGlobalEchoBufferSize = std::max(musics[i].echoBufferSize, maxGlobalEchoBufferSize);
+				int extPos = fname.find_last_of('.');
+				if (extPos != -1)
+					fname = fname.substr(0, extPos);
+			
+				if (fname.find('/') != -1)
+					fname = fname.substr(fname.find_last_of('/') + 1);
+				else if (fname.find('\\') != -1)
+					fname = fname.substr(fname.find_last_of('\\') + 1);
+				fname = "stats/" + fname + ".txt";
+				musics[i].statFName = fname;
+				
+				musics[i].compile();
+				if (i <= highestGlobalSong) {
+					maxGlobalEchoBufferSize = std::max(musics[i].echoBufferSize, maxGlobalEchoBufferSize);
+				}
+				totalSamplecount += musics[i].mySamples.size();
+				//}
 			}
-			totalSamplecount += musics[i].mySamples.size();
-			//}
 		}
 	}
 
@@ -1103,10 +1107,15 @@ void compileMusic()
 	{
 		if (i % 16 == 0)
 			songSampleList << "\ndw ";
-		if (musics[i].exists == false)
+		if (musics.count(i)) {
 			songSampleList << "$" << hex4 << 0;
-		else
+		}
+		else if (musics[i].exists == false) {
+			songSampleList << "$" << hex4 << 0;
+		}
+		else {
 			songSampleList << "SGPointer" << hex2 << i;
+		}
 		songSampleListSize += 2;
 
 		if (i != songCount - 1 && (i & 0xF) != 0xF)
@@ -1124,6 +1133,7 @@ void compileMusic()
 
 	for (int i = 0; i < songCount; i++)
 	{
+		if (musics.count(i) == 0) continue;
 		if ((!musics[i].exists) || (musicInSampleList[i])) continue;
 
 		songSampleListSize++;
@@ -1134,6 +1144,7 @@ void compileMusic()
 		{
 			for (int j = highestGlobalSong+1; j < songCount; j++) {
 				if (i == j) continue;
+				if (musics.count(j) == 0) continue;
 				if (!musics[j].exists) continue;
 				if (musics[i].mySamples.size() != musics[j].mySamples.size()) continue;
 				bool sampleGroupMatch = true;
@@ -1188,6 +1199,7 @@ void fixMusicPointers()
 
 	for (int i = 0; i < 256; i++)
 	{
+		if (musics.count(i) == 0) continue;
 		if (musics[i].exists == false) continue;
 
 		musics[i].posInARAM = songDataARAMPos;
@@ -1582,7 +1594,10 @@ void generateSPCs()
 
 		for (unsigned int i = 0; i < 256; i++)
 		{
-			if (mode == 0 && musics[i].exists == false) continue;
+			if (mode == 0) {
+				if (musics.count(i) == 0) continue;
+				if (musics[i].exists == false) continue;
+			}
 			if (mode == 1 && soundEffects[0][i].exists == false) continue;
 			if (mode == 2 && soundEffects[1][i].exists == false) continue;
 
@@ -1627,9 +1642,11 @@ void generateSPCs()
 				if (mode != 0) {
 					i = highestGlobalSong + 1;
 					for (int j = highestGlobalSong+1; j < 256; j++) {
-						if (musics[j].exists) {
-							i = j;		// While dumping SFX, pretend that the current song is the lowest valid local song
-							break;
+						if (musics.count(j)) {
+							if (musics[j].exists) {
+								i = j;		// While dumping SFX, pretend that the current song is the lowest valid local song
+								break;
+							}
 						}
 					}
 				}
@@ -1831,27 +1848,32 @@ void assembleSNESDriver2()
 
 	for (int i = 0; i < songCount; i++)
 	{
-		if (musics[i].exists == true && i > highestGlobalSong)
-		{
-			int requestSize;
-			int freeSpace;
-			std::stringstream musicBinPath;
-			musicBinPath << "asm/SNES/bin/music" << hex2 << i << ".bin";
-			requestSize = getFileSize(musicBinPath.str());
-			freeSpace = findFreeSpace(requestSize, bankStart, rom);
-			if (freeSpace == -1)
+		if (musics.count(i)) {
+			if (musics[i].exists == true && i > highestGlobalSong)
 			{
-				printError("Error: Your ROM is out of free space.", true);
+				int requestSize;
+				int freeSpace;
+				std::stringstream musicBinPath;
+				musicBinPath << "asm/SNES/bin/music" << hex2 << i << ".bin";
+				requestSize = getFileSize(musicBinPath.str());
+				freeSpace = findFreeSpace(requestSize, bankStart, rom);
+				if (freeSpace == -1)
+				{
+					printError("Error: Your ROM is out of free space.", true);
+				}
+	
+				freeSpace = PCToSNES(freeSpace);
+				musicPtrStr << "music" << hex2 << i << "+8";
+				musicIncbins << "org $" << hex6 << freeSpace << "\nmusic" << hex2 << i << ": incbin \"bin/music" << hex2 << i << ".bin\"" << std::endl;
 			}
-
-			freeSpace = PCToSNES(freeSpace);
-			musicPtrStr << "music" << hex2 << i << "+8";
-			musicIncbins << "org $" << hex6 << freeSpace << "\nmusic" << hex2 << i << ": incbin \"bin/music" << hex2 << i << ".bin\"" << std::endl;
+			else
+			{
+				musicPtrStr << "$" << hex6 << 0;
+			}
 		}
 		else
 		{
 			musicPtrStr << "$" << hex6 << 0;
-
 		}
 
 		if ((i & 0xF) == 0xF && i != songCount-1)
@@ -1994,12 +2016,14 @@ void generateMSC()
 
 	for (int i = 0; i < 256; i++)
 	{
-		if (musics[i].exists)
-		{
-			text << hex2 << i << "\t" << 0 << "\t" << musics[i].title << "\n";
-			text << hex2 << i << "\t" << 1 << "\t" << musics[i].title << "\n";
-			//fprintf(fout, "%2X\t0\t%s\n", i, musics[i].title.c_str());
-			//fprintf(fout, "%2X\t1\t%s\n", i, musics[i].title.c_str());
+		if (musics.count(i)){
+			if (musics[i].exists)
+			{
+				text << hex2 << i << "\t" << 0 << "\t" << musics[i].title << "\n";
+				text << hex2 << i << "\t" << 1 << "\t" << musics[i].title << "\n";
+				//fprintf(fout, "%2X\t0\t%s\n", i, musics[i].title.c_str());
+				//fprintf(fout, "%2X\t1\t%s\n", i, musics[i].title.c_str());
+			}
 		}
 	}
 	writeTextFile(mscname, text.str());
@@ -2124,8 +2148,13 @@ void checkMainTimeStamps()			// Disabled for now, as this only works if the ROM 
 		goto recompile;				// More laziness!
 	}
 
-	for (int i = 1; i <= highestGlobalSong; i++)
-		mostRecentMainModification = std::max(mostRecentMainModification, getTimeStamp((File)("music/" + musics[i].name)));
+	for (int i = 1; i <= highestGlobalSong; i++) {
+		if (musics.count(i)) {
+			if (musics[i].exists) {
+				mostRecentMainModification = std::max(mostRecentMainModification, getTimeStamp((File)("music/" + musics[i].name)));
+			}
+		}
+	}
 
 	mostRecentMainModification = std::max(mostRecentMainModification, getTimeStamp((File)"asm/main.asm"));
 	mostRecentMainModification = std::max(mostRecentMainModification, getTimeStamp((File)"asm/commands.asm"));
@@ -2168,8 +2197,8 @@ void generatePNGs()
 {
 	for (auto &current : musics)
 	{
-		if (current.index <= highestGlobalSong) continue;
-		if (current.exists == false) continue;
+		if (current.second.index <= highestGlobalSong) continue;
+		if (current.second.exists == false) continue;
 
 		std::vector<unsigned char> bitmap;
 		// 1024 pixels wide, 64 pixels tall, 4 bytes per pixel
@@ -2199,28 +2228,28 @@ void generatePNGs()
 				r = 255;
 				g = 255;
 			}
-			else if (i >= current.spaceInfo.songStartPos && i < current.spaceInfo.songEndPos)
+			else if (i >= current.second.spaceInfo.songStartPos && i < current.second.spaceInfo.songEndPos)
 			{
 				g = 128;
 			}
-			else if (i >= current.spaceInfo.sampleTableStartPos && i < current.spaceInfo.sampleTableEndPos)
+			else if (i >= current.second.spaceInfo.sampleTableStartPos && i < current.second.spaceInfo.sampleTableEndPos)
 			{
 				g = 255;
 			}
-			else if (i >= current.spaceInfo.individualSampleStartPositions[0] && i < current.spaceInfo.individualSampleEndPositions[current.spaceInfo.individualSampleEndPositions.size() - 1])
+			else if (i >= current.second.spaceInfo.individualSampleStartPositions[0] && i < current.second.spaceInfo.individualSampleEndPositions[current.second.spaceInfo.individualSampleEndPositions.size() - 1])
 			{
 				int currentSampleIndex = 0;
 
-				for (auto currentSampleEndPos : current.spaceInfo.individualSampleEndPositions)
+				for (auto currentSampleEndPos : current.second.spaceInfo.individualSampleEndPositions)
 				{
 					if (currentSampleEndPos > i) break;
 
 					currentSampleIndex++;
 				}
 
-				bool sampleIsImportant = current.spaceInfo.individialSampleIsImportant[currentSampleIndex];
+				bool sampleIsImportant = current.second.spaceInfo.individialSampleIsImportant[currentSampleIndex];
 
-				int sampleCount = current.spaceInfo.individualSampleStartPositions.size();
+				int sampleCount = current.second.spaceInfo.individualSampleStartPositions.size();
 
 				b = static_cast<unsigned char>(static_cast<double>(currentSampleIndex) / static_cast<double>(sampleCount)* 127.0 + 128.0);
 
@@ -2230,12 +2259,12 @@ void generatePNGs()
 					g = static_cast<unsigned char>(static_cast<double>(currentSampleIndex) / static_cast<double>(sampleCount)* 127.0 + 128.0);
 				}
 			}
-			else if (i >= current.spaceInfo.echoBufferStartPos && i < current.spaceInfo.echoBufferEndPos)
+			else if (i >= current.second.spaceInfo.echoBufferStartPos && i < current.second.spaceInfo.echoBufferEndPos)
 			{
 				r = 160;
 				b = 160;
 			}
-			else if (i >= current.spaceInfo.echoBufferEndPos)
+			else if (i >= current.second.spaceInfo.echoBufferEndPos)
 			{
 				r = 63;
 				b = 63;
@@ -2261,7 +2290,7 @@ void generatePNGs()
 			}
 		}
 
-		auto path = current.pathlessSongName;
+		auto path = current.second.pathlessSongName;
 		path = "Visualizations/" + path + ".png";
 		lodepng::encode(path, bitmap, width, height);
 

--- a/src/AddmusicK/globals.cpp
+++ b/src/AddmusicK/globals.cpp
@@ -17,7 +17,8 @@
 //ROM rom;
 std::vector<uint8_t> rom;
 
-Music musics[256];
+//extern Music musics[256];
+std::map<int, Music> musics;
 //Sample samples[256];
 std::vector<Sample> samples;
 SoundEffect soundEffectsDF9[256];

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -57,7 +57,8 @@ class SampleGroup;
 //extern ROM rom;
 extern std::vector<uint8_t> rom;
 
-extern Music musics[256];
+//extern Music musics[256];
+extern std::map<int, Music> musics;
 //extern Sample samples[256];
 extern std::vector<Sample> samples;
 extern SoundEffect *soundEffects[2];	// soundEffects[2][256];


### PR DESCRIPTION
The musics variable has been transformed into a map in an attempt to prevent errors on the Windows size with the array defined being too big. The key used to distinguish these is the raw ID provided by the user.

The key system can be changed in the future when song groups are implemented: for now, the one ID system will do the trick.

This merge request closes #532.