### PR TITLE
Send !FreeRAM defines to their own file

### DIFF
--- a/asm/SNES/AMKFreeRAMDefines.asm
+++ b/asm/SNES/AMKFreeRAMDefines.asm
@@ -1,0 +1,15 @@
+;AddmusicK FreeRAM Defines
+;For AddmusicK 1.0.9
+
+!FreeRAM		= $7FB000
+!CurrentSong		= !FreeRAM+$00
+!NoUploadSamples	= !FreeRAM+$01
+!SongPositionLow	= !FreeRAM+$04
+!SongPositionHigh	= !FreeRAM+$05
+!SPCOutput1		= !SongPositionLow
+!SPCOutput2		= !SongPositionHigh
+!SPCOutput3		= !FreeRAM+$06
+!SPCOutput4		= !FreeRAM+$07
+!Trick			= !FreeRAM+$08
+!SampleCount		= !FreeRAM+$09
+!SRCNTableBuffer	= !FreeRAM+$0A

--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -37,20 +37,8 @@ endif
 
 !SampleGroupPtrsLoc	= $008000
 
-!FreeRAM		= $7FB000
-!CurrentSong		= !FreeRAM+$00
-!NoUploadSamples	= !FreeRAM+$01
-!SongPositionLow	= !FreeRAM+$04
-!SongPositionHigh	= !FreeRAM+$05
-!SPCOutput1		= !SongPositionLow
-!SPCOutput2		= !SongPositionHigh
-!SPCOutput3		= !FreeRAM+$06
-!SPCOutput4		= !FreeRAM+$07
-;!MusicBackup		= !FreeRAM+$08
-!SampleCount		= !FreeRAM+$09
-!SRCNTableBuffer	= !FreeRAM+$0A
+incsrc "AMKFreeRAMDefines.asm"
 
-!Trick   = !FreeRAM+$08
 !Tricker = !BonusEnd
 
 ; FREERAM requires anywhere between 2 to potentially 1032 bytes of unused RAM (though somewhere in the range of, say, 100 is much more likely).

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -293,6 +293,7 @@
 		<li>"Fixed a bug where the echo buffer size to allocate was not factoring in the $F6 hex command when writing to the EDL DSP register." - KungFuFurby</li>
 		<li>"Added memory remaining statements to output and stats.txt files." - KungFuFurby</li>
 		<li>"The limitations of the EDL register are now factored in when calculating the echo buffer size to allocate: that is, they only go from $00-$0F." - KungFuFurby</li>
+		<li>"!FreeRAM is now stored in a separate ASM file, AMKFreeRAMDefines.asm, in the asm/SNES directory. This file is intended to be used for patch files in case !FreeRAM changes so that the defines can be modified as needed (and recycled by multiple patch files)." - KungFuFurby</li>
 		</ul>
 	</li>
 	<li>SPC700-Side ASM


### PR DESCRIPTION
These !FreeRAM defines are designed to be redistributable with notes on what the earliest compatible version of AddmusicK (assuming a finalized release or a release candidate). These may be changed if used in a fork: for those cases, the file will be updated accordingly.

The reason why this is done is because of a pending change to !FreeRAM that would affect the memory locations of multiple locations. This file is for patches that rely on AddmusicK to use to avoid having to update the patch files after this file becomes more officially supported. Note that this only contains AddmusicK-specific memory locations, not vanilla ones.

This !FreeRAM define file is compatible with AddmusicK 1.0.9 and later. It is also mostly compatible with AddmusicK 1.0.8 and earlier: the only difference between the two is that !Trick is not present and thus will have no effect unless you're using JUMP Team's fork, which is the origin of the code in question (and is not used anyways if !PSwitchStarRestart is disabled).

This merge request closes #534.