### PR TITLE
Use the calculated sample directory location from SpaceInfo when outputting SPC

### DIFF
--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -1671,7 +1671,7 @@ void generateSPCs()
 
 				}
 
-				int tablePos = localPos + musics[i].finalData.size();
+				int tablePos = musics[i].spaceInfo.sampleTableStartPos;
 
 				if ((tablePos & 0xFF) != 0)
 					tablePos = (tablePos & 0xFF00) + 0x100;


### PR DESCRIPTION
This allows for the SPC file to reflect the utilization of the #pad command as defined in the MML.

This merge request closes #491.