### PR TITLE
Implement reduced lag from switching songs using the exact same sample pack

### DIFF
--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -33,7 +33,7 @@ endif
 
 
 
-!Version = $00
+!Version = $01
 
 !SampleGroupPtrsLoc	= $008000
 

--- a/asm/SNES/patch.asm
+++ b/asm/SNES/patch.asm
@@ -305,7 +305,6 @@ endif
 	BNE ++				; |
 	STA !CurrentSong		; |
 	STA !MusicBackup		; |
-	STA !CurrentSongGroup		; |
 	JMP SPCNormal			; |
 ++					; /
 	LDA !MusicMir
@@ -364,7 +363,7 @@ endif
 ;	JMP Fade
 ;+
 
-	STA !CurrentSongGroup
+	PHA
 	
 
 	LDA #$FF		; Send this as early as possible
@@ -402,6 +401,34 @@ endif
 	INX
 	LDA MusicPtrs,x
 	STA $02
+
+	LDA.b #SampleGroupPtrs		; [$0D] is the pointer to this song's sample group.
+	STA $0D				; Sample groups contain the number of samples in their first byte
+	LDA.b #SampleGroupPtrs>>8	; Then the sample numbers themselves after that.
+	STA $0E
+	LDA.b #SampleGroupPtrs>>16
+	STA $0F
+	
+	LDA !MusicMir			; \
+	REP #$30			; |
+	AND #$00FF			; |
+	ASL				; | Index the table by the music number
+	TAY				; |
+	LDA !CurrentSongGroup		; |
+	AND #$00FF			; |
+	ASL				; |
+	TAX				; |
+	LDA [$0D],y			; /
+	TXY
+	CMP [$0D],y
+	STA $0D				; The sample groups are stored in the same bank as the table.
+	SEP #$30
+	BNE +
+	LDA.b #$01
+	STA !NoUploadSamples
++
+	PLA
+	STA !CurrentSongGroup
 	
 	REP #$10
 	LDX #!DefARAMRet
@@ -428,40 +455,10 @@ endif
 	JMP SPCNormal
 +
 	
-	REP #$20
-	
-	LDY #$02		; \
-	LDA [$00]		; | 
-	STA $09			; |
-	LDA [$00],y		; | This puts the location of the ARAM sample table into $09.
-	CLC			; |
-	ADC $09			; |
-	XBA : XBA		; | Test the low byte of the accumulator
-	BEQ NoAdd		; |
-	CLC			; | The low byte of the sample table must be 0.
-	ADC #$0100		; |
-	AND #$FF00		; |
-NoAdd:	STA $09			; /
-	
-
-	SEP #$20
-	
-					
-	LDA.b #SampleGroupPtrs		; [$0D] is the pointer to this song's sample group.
-	STA $0D				; Sample groups contain the number of samples in their first byte
-	LDA.b #SampleGroupPtrs>>8	; Then the sample numbers themselves after that.
-	STA $0E
-	LDA.b #SampleGroupPtrs>>16
-	STA $0F
-	
-	LDA !MusicMir			; \
-	REP #$30			; |
-	AND #$00FF			; |
-	ASL				; | Index the table by the music number
-	TAY				; |
-	LDA [$0D],y			; /
-	STA $0D				; The sample groups are stored in the same bank as the table.
-	SEP #$30
+	LDA [$0D]			; Get the sample directory pointer.
+	STA $0A
+	STZ $09
+	INC $0D
 	
 	LDA [$0D]			; Get the number of samples
 	STA !SampleCount

--- a/readme_files/changelog.html
+++ b/readme_files/changelog.html
@@ -263,6 +263,7 @@
 	<li>Overall
 		<ul>
 		<li>"The way the music collection has been handled internally has been modified in terms of its data type: instead of using an array of 256 entries, they now use maps. This will help prevent future complaints from compilers due to too much memory being requested for allocation for an array of music instances." - KungFuFurby</li>
+		<li>"<b>The data version has been incremented due to a change in the way the sample packs are defined on the SNES side.</b>" - KungFuFurby</li>
 		</ul>
 	</li>
 	<li>Command Line
@@ -277,6 +278,7 @@
 		<li>"Added a filter for hijacks that conflict with Yoshifanatic's Overworld Revolution patch." - KungFuFurby</li>
 		<li>"Fixed a bug where changing level music while the Starman or P-Switch songs were active would cause the next level music to fail to load upon the conclusion of the Starman and/or the P-Switch effect." - KungFuFurby</li>
 		<li>"Added a new user define, !TimerResetOnLevelFade . This define is designed to allow patches that allow P-Switch, star and directional coin timers to persist between rooms that would otherwise fail when AddmusicK is applied on top of these patches." - KungFuFurby</li>
+		<li>"The sample pack is no longer reloaded when switching local songs if it is exactly the same sample pack that was loaded before and it can be kept in the same memory location." - KungFuFurby</li>
 		</ul>
 	</li>
 	<li>Built-In Original Songs
@@ -313,6 +315,7 @@
 		<li>"Fixed a bug where the first generated SPC file has an extra EMPTY.brr sample slot when running in -norom with all global songs removed." - nyanpasu64</li>
 		<li>"Fixed a bug where the sample directory was not being properly relocated in SPC exports when using #pad." - KungFuFurby</li>
 		<li>"The use of #pad in songs is now acknowledged as part of the memory usage reporting provided by the program." - KungFuFurby</li>
+		<li>"All sample packs in the ROM now include a sample directory location in them instead of calculating where it is when loading a new local song. This is so that the sample pack does not need to be reloaded if it is the exact same one and its memory location has also not changed." - KungFuFurby</li>
 		</ul>
 	</li>
 	<li>SPC700-Side ASM

--- a/src/AddmusicK/AddmusicK.cpp
+++ b/src/AddmusicK/AddmusicK.cpp
@@ -33,6 +33,7 @@ void compileSFX();
 void compileGlobalData();
 void compileMusic();
 void fixMusicPointers();
+void compileSamplePacks();
 void generateSPCs();
 void assembleSNESDriver2();
 void generateMSC();
@@ -249,6 +250,7 @@ int main(int argc, char* argv[]) try		// // //
 
 	compileMusic();
 	fixMusicPointers();
+	compileSamplePacks();
 
 	generateSPCs();
 
@@ -1057,7 +1059,7 @@ void compileMusic()
 		std::cout << "Compiling music..." << std::endl;
 
 	int totalSamplecount = 0;
-	int totalSize = 0;
+	//int totalSize = 0;
 	int maxGlobalEchoBufferSize = 0;
 	for (int i = 0; i < 256; i++)
 	{
@@ -1092,7 +1094,13 @@ void compileMusic()
 			}
 		}
 	}
+}
 
+void compileSamplePacks()
+{
+	if (verbose)
+		std::cout << "Compiling sample packs..." << std::endl;
+	
 	//int songSampleListSize = 0;
 
 	//for (int i = 0; i < songCount; i++)
@@ -1136,15 +1144,14 @@ void compileMusic()
 		musicInSampleList[i] = false;
 	}
 
+	std::map<int, std::vector<int>> samplePackToMusic;
+	int samplePackID = 0;
+	
 	for (int i = 0; i < songCount; i++)
 	{
 		if (musics.count(i) == 0) continue;
 		if ((!musics[i].exists) || (musicInSampleList[i])) continue;
-
-		songSampleListSize++;
-
-		songSampleList << "\n" << "SGPointer" << hex2 << i << ":\n";
-
+		samplePackToMusic[samplePackID].push_back(i);
 		if (i > highestGlobalSong)
 		{
 			for (int j = highestGlobalSong+1; j < songCount; j++) {
@@ -1157,23 +1164,81 @@ void compileMusic()
 				{
 					if ((musics[i].mySamples[k]) != (musics[j].mySamples[k])){
 						sampleGroupMatch = false;
+						break;
 					}
 				}
 				if (sampleGroupMatch) {
-					songSampleList << "\n" << "SGPointer" << hex2 << j << ":\n";
 					musicInSampleList[j] = true;
+					samplePackToMusic[samplePackID].push_back(j);
 				}
 			}
-			songSampleList << "db $" << hex2 << musics[i].mySamples.size() << "\ndw";
-			for (unsigned int j = 0; j < musics[i].mySamples.size(); j++)
-			{
-				songSampleListSize+=2;
-				songSampleList << " $" << hex4 << (int)(musics[i].mySamples[j]);
-				if (j != musics[i].mySamples.size() - 1)
-					songSampleList << ",";
-			}
+			int newSamplePacks = 1;
+			//If any songs' sample packs overlap the echo buffer after pushing out the sample directory, assign a new pack instead.
+			if (checkEcho) {
+				for (int j = 0; j < newSamplePacks; j++) {
+					bool newSamplePackNeeded = false;
+					//Identify the sample table directory our sample pack will be assigned.
+					int samplePackSampleTableDir = 0;
+					for (int k = 0; k < samplePackToMusic[samplePackID+j].size(); k++) {
+						int l = samplePackToMusic[samplePackID+j][k];
+						if (l <= highestGlobalSong) continue;
+						samplePackSampleTableDir = std::max(musics[l].spaceInfo.sampleTableStartPos, samplePackSampleTableDir);
+					}
+					for (int k = 0; k < samplePackToMusic[samplePackID+j].size(); k++) {
+						int l = samplePackToMusic[samplePackID+j][k];
+						if (l <= highestGlobalSong) continue;
+						if (musics[l].echoBufferSize == 0 && !musics[l].usesEcho) continue;
+						int samplePackTableDirOffset = samplePackSampleTableDir - musics[l].spaceInfo.sampleTableStartPos;
+						if (musics[l].spaceInfo.endOfSongAndSampleDataPos+samplePackTableDirOffset >= musics[l].spaceInfo.echoBufferStartPos) {
+							samplePackToMusic[samplePackID+j+1].push_back(l);
+							samplePackToMusic[samplePackID+j].erase(samplePackToMusic[samplePackID+j].begin()+k);
+							k--;
+							newSamplePackNeeded = true;
+						}
+					}
+					if (newSamplePackNeeded) newSamplePacks++;
+				}
+			}	
+			samplePackID += newSamplePacks;
 		}
+	}
+	
+	for (auto &samplePackEntry : samplePackToMusic)
+	{
+		int samplePackSampleTableDir = 0x0000;
+		for (int i = 0; i < samplePackEntry.second.size(); i++)
+		{
+			songSampleListSize++;
 
+			songSampleList << "\n" << "SGPointer" << hex2 << samplePackEntry.second[i] << ":\n";
+			
+			samplePackSampleTableDir = std::max(musics[samplePackEntry.second[i]].spaceInfo.sampleTableStartPos, samplePackSampleTableDir);
+		}
+		//Update the musics sampleTableStartPos and sampleTableEndPos entries for SPC generation and visualization updates
+		for (int i = 0; i < samplePackEntry.second.size(); i++) {
+			if (samplePackEntry.second[i] <= highestGlobalSong) continue;
+			int samplePackTableDirOffset = samplePackSampleTableDir - musics[samplePackEntry.second[i]].spaceInfo.sampleTableStartPos;
+			
+			musics[samplePackEntry.second[i]].spaceInfo.sampleTableStartPos += samplePackTableDirOffset;
+			musics[samplePackEntry.second[i]].spaceInfo.sampleTableEndPos += samplePackTableDirOffset;
+			for (int j = 0; j < musics[samplePackEntry.second[i]].spaceInfo.individualSampleStartPositions.size(); j++) {
+				musics[samplePackEntry.second[i]].spaceInfo.individualSampleStartPositions[j] += samplePackTableDirOffset;
+				musics[samplePackEntry.second[i]].spaceInfo.individualSampleEndPositions[j] += samplePackTableDirOffset;
+			}
+			musics[samplePackEntry.second[i]].spaceInfo.endOfSongAndSampleDataPos += samplePackTableDirOffset;
+			
+		}
+		samplePackSampleTableDir = ((samplePackSampleTableDir >> 8) & 0xff);
+		songSampleList << "db $" << hex2 << samplePackSampleTableDir << " ;DIR DSP register location\n";
+		songSampleList << "db $" << hex2 << musics[samplePackEntry.second[0]].mySamples.size() << " ;Number of samples in sample group\ndw";
+		for (unsigned int i = 0; i < musics[samplePackEntry.second[0]].mySamples.size(); i++)
+		{
+			songSampleListSize+=2;
+			songSampleList << " $" << hex4 << (int)(musics[samplePackEntry.second[0]].mySamples[i]);
+			if (i != musics[samplePackEntry.second[0]].mySamples.size() - 1)
+				songSampleList << ",";
+		}
+		songSampleList << "\n\n";
 	}
 	songSampleList << "\nSGEnd:";
 	s = songSampleList.str();
@@ -1345,7 +1410,7 @@ void fixMusicPointers()
 		}
 		else
 		{
-			//We need to do the memory calculations for the visualization in case the user wants them... even if the memory overflows.
+			//We need to do the memory calculations for the visualization in case the user wants them... even if the memory overflows. That, and we also want the sample table locations from here.
 			musics[i].spaceInfo.songStartPos = songDataARAMPos;
 			musics[i].spaceInfo.songEndPos = musics[i].spaceInfo.songStartPos + sizeWithPadding;
 
@@ -1387,6 +1452,7 @@ void fixMusicPointers()
 			}
 			musics[i].spaceInfo.importantSampleCount = importantSampleCount;
 
+			musics[i].spaceInfo.endOfSongAndSampleDataPos = checkPos;
 			int endOfSongAndSampleDataPos = checkPos;
 			
 			if ((checkPos & 0xFF) != 0) checkPos = ((checkPos >> 8) + 1) << 8;

--- a/src/AddmusicK/Music.h
+++ b/src/AddmusicK/Music.h
@@ -13,6 +13,7 @@ struct SpaceInfo {
 	std::vector<int> individualSampleStartPositions;
 	std::vector<int> individualSampleEndPositions;
 	std::vector<bool> individialSampleIsImportant;
+	int endOfSongAndSampleDataPos;
 	int importantSampleCount;
 	int echoBufferEndPos;
 	int echoBufferStartPos;

--- a/src/AddmusicK/globals.h
+++ b/src/AddmusicK/globals.h
@@ -26,7 +26,7 @@
 
 #define PARSER_VERSION 4			// Used to keep track of incompatible changes to the parser
 
-#define DATA_VERSION 0				// Used to keep track of incompatible changes to any and all compiled data, either to the SNES or to the PC
+#define DATA_VERSION 1				// Used to keep track of incompatible changes to any and all compiled data, either to the SNES or to the PC
 
 #include <cstdint>		// // //
 //class ROM;


### PR DESCRIPTION
Multiple things were modified to pull this off:
- The sample pack format has been modified to add a sample directory location to
  the very first byte. This is the reason why the data version was incremented.
- I had to reorder some things in terms of compilation order in order to
  calculate the sample directory location first, since that is required to be
  known in order to compile the sample packs.

Note that currently I do comparisons via simply matching the pointers from the
previous song loaded to the next because deduplication was implemented earlier.

This merge request mentions https://github.com/KungFuFurby/AddMusicKFF/issues/450. It doesn't close it, mostly because there's something
else conceptually that can be done to further reduce loading via add-on packs,
which aren't implemented here.